### PR TITLE
Add thoughts feature - personal micro-blog section

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -65,4 +65,5 @@ const { current = '' } = Astro.props;
   <a class={current === "" ? "selected" : ""} href='/'>home</a>
   <a class={current === "about" ? "selected" : ""} href='/about'>about</a>
   <a class={current === "blog" ? "selected" : ""} href='/blog'>blog</a>
+  <a class={current === "thoughts" ? "selected" : ""} href='/thoughts'>thoughts</a>
 </nav>

--- a/src/data/thoughts/published/20250117-ai-musings.md
+++ b/src/data/thoughts/published/20250117-ai-musings.md
@@ -1,0 +1,6 @@
+---
+content: Teaching an AI to code is like teaching a very eager student who never sleeps and occasionally hallucinates entire programming languages.
+publishDate: 17 Jan 2025
+publishTime: 3:15 PM
+tags: ["ai", "programming", "tech"]
+---

--- a/src/data/thoughts/published/20250118-late-night-debugging.md
+++ b/src/data/thoughts/published/20250118-late-night-debugging.md
@@ -1,0 +1,6 @@
+---
+content: That moment when you've been debugging for 2 hours only to realize you forgot a semicolon. JavaScript optional semicolons are both a blessing and a curse.
+publishDate: 18 Jan 2025
+publishTime: 11:45 PM
+tags: ["debugging", "javascript", "programming"]
+---

--- a/src/data/thoughts/published/20250119-coffee-thoughts.md
+++ b/src/data/thoughts/published/20250119-coffee-thoughts.md
@@ -1,0 +1,6 @@
+---
+content: Coffee number 3 today. At this point I'm basically a sophisticated water filter that turns coffee into code.
+publishDate: 19 Jan 2025
+publishTime: 11:30 AM
+tags: ["coffee", "coding", "life"]
+---

--- a/src/data/thoughts/published/20250119-first-thought.md
+++ b/src/data/thoughts/published/20250119-first-thought.md
@@ -1,0 +1,6 @@
+---
+content: Just shipped a mini Twitter clone feature on my personal site. No likes, no retweets, just thoughts floating in the digital void. Sometimes the best social media is antisocial media.
+publishDate: 19 Jan 2025
+publishTime: 2:45 PM
+tags: ["meta", "web dev", "thoughts"]
+---

--- a/src/pages/admin/new-thought.astro
+++ b/src/pages/admin/new-thought.astro
@@ -1,0 +1,231 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const title = 'New Thought';
+const description = 'Create a new thought';
+const permalink = `${Astro.site.href}admin/new-thought`;
+---
+
+<BaseLayout title={title} description={description} permalink={permalink}>
+  <div class="container">
+    <h1>Create New Thought</h1>
+    <form id="thought-form">
+      <div class="form-group">
+        <label for="content">Thought</label>
+        <textarea 
+          id="content" 
+          name="content" 
+          rows="4" 
+          maxlength="280"
+          placeholder="What's on your mind? (280 chars max)"
+          required
+        ></textarea>
+        <div class="char-count">
+          <span id="char-current">0</span> / 280
+        </div>
+      </div>
+      
+      <div class="form-group">
+        <label for="tags">Tags (comma separated)</label>
+        <input 
+          type="text" 
+          id="tags" 
+          name="tags" 
+          placeholder="coffee, coding, life"
+        />
+      </div>
+      
+      <button type="submit">Generate Markdown</button>
+    </form>
+    
+    <div id="output" class="output hidden">
+      <h2>Generated Markdown</h2>
+      <pre><code id="markdown-output"></code></pre>
+      <button id="copy-btn">Copy to Clipboard</button>
+    </div>
+    
+    <div class="instructions">
+      <h3>Instructions:</h3>
+      <ol>
+        <li>Fill out the form above</li>
+        <li>Click "Generate Markdown"</li>
+        <li>Copy the generated markdown</li>
+        <li>Create a new file in <code>src/data/thoughts/published/</code></li>
+        <li>Name it <code>YYYYMMDD-short-slug.md</code></li>
+        <li>Paste the markdown content and save</li>
+      </ol>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .container {
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .form-group {
+    margin-bottom: 1.5rem;
+  }
+
+  label {
+    display: block;
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+    font-family: var(--font-family-sans);
+  }
+
+  textarea, input[type="text"] {
+    width: 100%;
+    padding: 0.75rem;
+    border: 1px solid var(--text-secondary);
+    border-radius: 4px;
+    font-family: var(--font-family-serif);
+    font-size: 1rem;
+    background: var(--background-body);
+    color: var(--text-main);
+  }
+
+  textarea {
+    resize: vertical;
+    min-height: 100px;
+  }
+
+  .char-count {
+    text-align: right;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    margin-top: 0.25rem;
+    font-family: var(--font-family-sans);
+  }
+
+  button {
+    background: var(--primary-color);
+    color: white;
+    border: none;
+    padding: 0.75rem 1.5rem;
+    border-radius: 4px;
+    font-family: var(--font-family-sans);
+    font-weight: 600;
+    cursor: pointer;
+    transition: opacity 0.2s ease;
+  }
+
+  button:hover {
+    opacity: 0.9;
+  }
+
+  .output {
+    margin-top: 2rem;
+    padding: 1.5rem;
+    background: var(--background);
+    border: 1px solid var(--text-secondary);
+    border-radius: 4px;
+  }
+
+  .output.hidden {
+    display: none;
+  }
+
+  .output h2 {
+    margin-top: 0;
+    font-family: var(--font-family-sans);
+  }
+
+  pre {
+    background: var(--background-body);
+    padding: 1rem;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+
+  code {
+    font-family: 'Courier New', monospace;
+    font-size: 0.9rem;
+  }
+
+  .instructions {
+    margin-top: 3rem;
+    padding: 1.5rem;
+    background: var(--background);
+    border-radius: 4px;
+  }
+
+  .instructions h3 {
+    margin-top: 0;
+    font-family: var(--font-family-sans);
+  }
+
+  .instructions ol {
+    margin-bottom: 0;
+  }
+
+  .instructions code {
+    background: var(--background-body);
+    padding: 0.2rem 0.4rem;
+    border-radius: 3px;
+  }
+</style>
+
+<script>
+  const contentInput = document.getElementById('content') as HTMLTextAreaElement;
+  const charCurrent = document.getElementById('char-current');
+  const form = document.getElementById('thought-form') as HTMLFormElement;
+  const output = document.getElementById('output');
+  const markdownOutput = document.getElementById('markdown-output');
+  const copyBtn = document.getElementById('copy-btn');
+
+  // Character counter
+  contentInput.addEventListener('input', () => {
+    if (charCurrent) {
+      charCurrent.textContent = contentInput.value.length.toString();
+    }
+  });
+
+  // Form submission
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    
+    const content = contentInput.value.trim();
+    const tagsInput = (document.getElementById('tags') as HTMLInputElement).value;
+    const tags = tagsInput.split(',').map(tag => tag.trim()).filter(tag => tag);
+    
+    const now = new Date();
+    const publishDate = now.toLocaleDateString('en-US', { 
+      day: 'numeric', 
+      month: 'short', 
+      year: 'numeric' 
+    });
+    const publishTime = now.toLocaleTimeString('en-US', { 
+      hour: 'numeric', 
+      minute: '2-digit',
+      hour12: true 
+    });
+    
+    const markdown = `---
+content: ${content}
+publishDate: ${publishDate}
+publishTime: ${publishTime}
+tags: ${JSON.stringify(tags)}
+---`;
+    
+    if (markdownOutput) {
+      markdownOutput.textContent = markdown;
+    }
+    
+    if (output) {
+      output.classList.remove('hidden');
+    }
+  });
+
+  // Copy to clipboard
+  copyBtn?.addEventListener('click', () => {
+    if (markdownOutput) {
+      navigator.clipboard.writeText(markdownOutput.textContent || '');
+      copyBtn.textContent = 'Copied!';
+      setTimeout(() => {
+        copyBtn.textContent = 'Copy to Clipboard';
+      }, 2000);
+    }
+  });
+</script>

--- a/src/pages/thoughts/[slug].astro
+++ b/src/pages/thoughts/[slug].astro
@@ -1,0 +1,108 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export async function getStaticPaths() {
+  const thoughts = await Astro.glob('../../data/thoughts/published/*.md');
+  return thoughts.map(t => ({
+    params: { slug: t.file.split('/').pop().split('.').shift() },
+    props: { thought: t },
+  }));
+}
+
+const { frontmatter } = Astro.props.thought;
+const { content, publishDate, publishTime, tags } = frontmatter;
+const slug = Astro.props.thought.file.split('/').pop().split('.').shift();
+const permalink = `${Astro.site.href}thoughts/${slug}`;
+---
+
+<BaseLayout title="Thought" description={content.substring(0, 100) + '...'} permalink={permalink} current="thoughts">
+  <div class="container">
+    <article class="thought-single">
+      <div class="thought-header">
+        <time>{publishDate} at {publishTime}</time>
+      </div>
+      <div class="thought-body">
+        <p>{content}</p>
+      </div>
+      {tags && tags.length > 0 && (
+        <div class="thought-tags">
+          {tags.map((tag) => (
+            <span class="tag">#{tag}</span>
+          ))}
+        </div>
+      )}
+    </article>
+    <div class="back-link">
+      <a href="/thoughts">← Back to all thoughts</a>
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .thought-single {
+    max-width: 600px;
+    margin: 4rem auto;
+    background: var(--background-body);
+    border: 1px solid var(--text-secondary);
+    border-radius: 12px;
+    padding: 2rem;
+  }
+
+  .thought-header {
+    margin-bottom: 1.5rem;
+  }
+
+  .thought-header time {
+    font-family: var(--font-family-sans);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+    text-transform: uppercase;
+  }
+
+  .thought-body p {
+    font-size: 1.3rem;
+    line-height: 1.8;
+    margin: 0;
+  }
+
+  .thought-tags {
+    margin-top: 1.5rem;
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    color: var(--primary-color);
+    font-family: var(--font-family-sans);
+    font-size: 0.9rem;
+    opacity: 0.8;
+  }
+
+  .back-link {
+    text-align: center;
+    margin: 3rem 0;
+  }
+
+  .back-link a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-family: var(--font-family-sans);
+    font-weight: 600;
+  }
+
+  .back-link a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 600px) {
+    .thought-single {
+      margin: 2rem auto;
+      padding: 1.5rem;
+    }
+
+    .thought-body p {
+      font-size: 1.1rem;
+    }
+  }
+</style>

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -1,0 +1,159 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const title = 'Thoughts';
+const description = 'Quick thoughts and musings - my personal micro-blog.';
+const permalink = `${Astro.site.href}thoughts`;
+
+let allThoughts = await Astro.glob('../../data/thoughts/published/*.md');
+allThoughts = allThoughts.sort((a, b) => {
+  const dateA = new Date(`${a.frontmatter.publishDate} ${a.frontmatter.publishTime}`);
+  const dateB = new Date(`${b.frontmatter.publishDate} ${b.frontmatter.publishTime}`);
+  return dateB.valueOf() - dateA.valueOf();
+});
+
+// Group thoughts by date
+const thoughtsByDate = allThoughts.reduce((acc, thought) => {
+  const date = thought.frontmatter.publishDate;
+  if (!acc[date]) {
+    acc[date] = [];
+  }
+  acc[date].push(thought);
+  return acc;
+}, {});
+---
+
+<BaseLayout title={title} description={description} permalink={permalink} current="thoughts">
+  <div class="container">
+    <h1>Thoughts</h1>
+    <p class="intro">Quick thoughts, observations, and shower thoughts. No comments, no likes, just vibes.</p>
+    
+    <div class="thoughts-container">
+      {Object.entries(thoughtsByDate).map(([date, thoughts]) => (
+        <div class="date-group">
+          <h2 class="date-header">{date}</h2>
+          {thoughts.map((thought) => {
+            const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
+            return (
+              <article class="thought-card">
+                <div class="thought-content">
+                  <p>{thought.frontmatter.content}</p>
+                </div>
+                <div class="thought-meta">
+                  <time>{thought.frontmatter.publishTime}</time>
+                  {thought.frontmatter.tags && thought.frontmatter.tags.length > 0 && (
+                    <span class="tags">
+                      {thought.frontmatter.tags.map((tag, index) => (
+                        <>
+                          {index > 0 && ' '}
+                          <span class="tag">#{tag}</span>
+                        </>
+                      ))}
+                    </span>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  </div>
+</BaseLayout>
+
+<style>
+  .intro {
+    color: var(--text-secondary);
+    font-style: italic;
+    margin-bottom: 3rem;
+  }
+
+  .thoughts-container {
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .date-group {
+    margin-bottom: 3rem;
+  }
+
+  .date-header {
+    font-family: var(--font-family-sans);
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--primary-color);
+  }
+
+  .thought-card {
+    background: var(--background-body);
+    border: 1px solid var(--text-secondary);
+    border-radius: 8px;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+    transition: all 0.2s ease;
+  }
+
+  .thought-card:hover {
+    border-color: var(--primary-color);
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  }
+
+  .thought-content {
+    margin-bottom: 1rem;
+  }
+
+  .thought-content p {
+    font-size: 1.1rem;
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  .thought-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+  }
+
+  .thought-meta time {
+    font-family: var(--font-family-sans);
+  }
+
+  .tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .tag {
+    color: var(--primary-color);
+    font-family: var(--font-family-sans);
+    font-size: 0.8rem;
+    opacity: 0.8;
+    transition: opacity 0.2s ease;
+  }
+
+  .tag:hover {
+    opacity: 1;
+  }
+
+  @media (max-width: 600px) {
+    .thought-card {
+      padding: 1rem;
+    }
+
+    .thought-content p {
+      font-size: 1rem;
+    }
+
+    .thought-meta {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.5rem;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Added a new "Thoughts" section separate from the blog for quick, Twitter-like posts
- Created a minimalist, card-based design with no engagement features (no likes, comments, etc)
- Implemented an admin page to easily generate markdown for new thoughts

## Features
- **280 character limit** for each thought (Twitter-style brevity)
- **Chronological display** grouped by date with newest first
- **Tag support** for categorizing thoughts
- **Responsive design** that works well on mobile
- **Admin tool** at `/admin/new-thought` for creating new thoughts
- **Clean, minimal aesthetic** that matches the site's existing style

## Implementation Details
- Thoughts are stored as markdown files in `src/data/thoughts/published/`
- Each thought has frontmatter with content, date, time, and optional tags
- Added "thoughts" to the main navigation menu
- Created listing page at `/thoughts` and individual pages at `/thoughts/[slug]`
- Included 4 sample thoughts to demonstrate the feature

## Test plan
- [ ] Visit `/thoughts` and verify the thoughts display correctly
- [ ] Check that thoughts are grouped by date and sorted properly
- [ ] Click on individual thoughts and verify the detail page works
- [ ] Test the responsive design on mobile devices
- [ ] Navigate to `/admin/new-thought` and test creating a new thought
- [ ] Verify the navigation link appears and is highlighted when active
- [ ] Check that the styling matches the overall site aesthetic

🤖 Generated with [Claude Code](https://claude.ai/code)