### PR TITLE
Add make-thought command and new thought

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: astro dev dev-clean dev-restart check-db kill-servers migrate-db
 .PHONY: users count info delete test-user find logout recent active cleanup stats
 .PHONY: users-list-prod sessions-cleanup-prod db-stats-prod
-.PHONY: help help-admin
+.PHONY: help help-admin thought
 
 # Development Commands
 # ====================
@@ -41,6 +41,10 @@ dev-restart: kill-servers check-db
 dev-clean: kill-servers migrate-db check-db
 	@echo "Starting fresh dev server with clean database..."
 	npm run dev
+
+# Create a new thought markdown file
+thought:
+	@test -n "$(SLUG)" && npm run make-thought $(SLUG) || npm run make-thought
 
 # User Management Commands
 # ========================
@@ -220,6 +224,9 @@ help:
 	@echo "  make logout EMAIL=...   - Force logout user"
 	@echo "  make delete EMAIL=...   - Delete user (requires typing DELETE)"
 	@echo
+	@echo "💭 Content:"
+	@echo "  make thought            - Create new thought (optional: SLUG=my-thought)"
+	@echo
 	@echo "🧹 Maintenance:"
 	@echo "  make cleanup            - Remove expired sessions"
 	@echo "  make dev-clean          - Restart with fresh database"
@@ -228,6 +235,7 @@ help:
 	@echo "  make find Q=test"
 	@echo "  make info EMAIL=test@example.com"
 	@echo "  make delete EMAIL=spam@example.com"
+	@echo "  make thought SLUG=my-new-idea"
 
 # Show all admin commands (detailed)
 help-admin:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "dev": "astro build && wrangler dev",
     "dev:pages": "astro build && wrangler pages dev dist/ --compatibility-date=2024-11-01 --compatibility-flags nodejs_compat --d1 DB=baba-is-win-db",
     "preview": "astro build && wrangler dev",
-    "types": "wrangler types"
+    "types": "wrangler types",
+    "make-thought": "node scripts/make-thought.js"
   },
   "type": "module"
 }

--- a/scripts/make-thought.js
+++ b/scripts/make-thought.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Get current date and time
+const now = new Date();
+const dateStr = now.toISOString().slice(0, 10).replace(/-/g, '');
+const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+const month = monthNames[now.getMonth()];
+const day = now.getDate();
+const year = now.getFullYear();
+const publishDate = `${day} ${month} ${year}`;
+
+// Format time as "H:MM PM/AM"
+let hours = now.getHours();
+const minutes = now.getMinutes();
+const ampm = hours >= 12 ? 'PM' : 'AM';
+hours = hours % 12;
+hours = hours ? hours : 12; // the hour '0' should be '12'
+const minutesStr = minutes < 10 ? '0' + minutes : minutes;
+const publishTime = `${hours}:${minutesStr} ${ampm}`;
+
+// Read template
+const templatePath = path.join(__dirname, '..', 'templates', 'thought.md');
+const template = fs.readFileSync(templatePath, 'utf8');
+
+// Replace placeholders
+const content = template
+  .replace('{{DATE}}', publishDate)
+  .replace('{{TIME}}', publishTime);
+
+// Generate filename with slug (can be customized later)
+const slug = process.argv[2] || 'new-thought';
+const filename = `${dateStr}-${slug}.md`;
+
+// Create output path
+const outputDir = path.join(__dirname, '..', 'src', 'data', 'thoughts', 'published');
+const outputPath = path.join(outputDir, filename);
+
+// Ensure directory exists
+fs.mkdirSync(outputDir, { recursive: true });
+
+// Write file
+fs.writeFileSync(outputPath, content);
+
+console.log(`Created new thought: ${outputPath}`);
+console.log(`\nOpen this file in your editor to add content and customize the tags, color, and images.`);

--- a/src/data/thoughts/published/20250625-new-thought.md
+++ b/src/data/thoughts/published/20250625-new-thought.md
@@ -1,11 +1,8 @@
 ---
 content: |
-    [Your thought content goes here]
+    I'm going to start referring to my ex-boyfriends as "legacy romance"
 publishDate: 24 Jun 2025
 publishTime: "7:16 PM"
 tags: ["tag1", "tag2", "tag3"]
 color: "#4a5568"
-images: [
-  { "url": "/assets/thoughts/example.png" },
-]
 ---

--- a/src/data/thoughts/published/20250625-new-thought.md
+++ b/src/data/thoughts/published/20250625-new-thought.md
@@ -1,8 +1,8 @@
 ---
 content: |
-    I'm going to start referring to my ex-boyfriends as "legacy romance"
+    I don't have ex-boyfriends. I have <em>legacy romance</em> ❤️
 publishDate: 24 Jun 2025
 publishTime: "7:16 PM"
-tags: ["tag1", "tag2", "tag3"]
-color: "#4a5568"
+tags: ["love", "romance", "dating", "advice", "inspiration"]
+color: "#722f37"
 ---

--- a/src/data/thoughts/published/20250625-new-thought.md
+++ b/src/data/thoughts/published/20250625-new-thought.md
@@ -1,0 +1,11 @@
+---
+content: |
+    [Your thought content goes here]
+publishDate: 24 Jun 2025
+publishTime: "7:16 PM"
+tags: ["tag1", "tag2", "tag3"]
+color: "#4a5568"
+images: [
+  { "url": "/assets/thoughts/example.png" },
+]
+---

--- a/templates/thought.md
+++ b/templates/thought.md
@@ -4,7 +4,7 @@ content: |
 publishDate: {{DATE}}
 publishTime: "{{TIME}}"
 tags: ["tag1", "tag2", "tag3"]
-color: "#4a5568"
+color: "#722f37"
 images: [
   { "url": "/assets/thoughts/example.png" },
 ]

--- a/templates/thought.md
+++ b/templates/thought.md
@@ -1,0 +1,11 @@
+---
+content: |
+    [Your thought content goes here]
+publishDate: {{DATE}}
+publishTime: "{{TIME}}"
+tags: ["tag1", "tag2", "tag3"]
+color: "#4a5568"
+images: [
+  { "url": "/assets/thoughts/example.png" },
+]
+---


### PR DESCRIPTION
## Summary
- Added `make-thought` command to easily create new thought markdown files
- Created thought template with placeholders for content, tags, color, and images
- Added `make thought` target to Makefile with optional SLUG parameter
- Automatically fills in current date/time when creating new thoughts
- Added new thought about "legacy romance"

## Usage
```bash
# Create with default filename
make thought

# Create with custom slug
make thought SLUG=my-new-idea

# Or use npm directly
npm run make-thought my-slug
```

🤖 Generated with [Claude Code](https://claude.ai/code)