### PR TITLE
Fix subtitle randomization on deployed site

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -329,7 +329,7 @@ const subtitleHTML = renderSubtitleHTML(selectedSubtitle);
 
     // Client-side subtitle randomization
     function randomizeSubtitle() {
-      const subtitles = JSON.parse(`{JSON.stringify(subtitlesData.subtitles)}`);
+      const subtitles = JSON.parse(`${JSON.stringify(subtitlesData.subtitles)}`);
       const randomIndex = Math.floor(Math.random() * subtitles.length);
       const selectedSubtitle = subtitles[randomIndex];
       


### PR DESCRIPTION
## Summary
• Fix template literal syntax error in subtitle randomization
• Missing `$` in template literal was causing JavaScript to fail silently
• Subtitle now properly randomizes on each page visit

## Test plan
- [x] Deploy and verify subtitles change on each page refresh
- [x] Verify no JavaScript console errors
- [x] Confirm subtitle links still work properly

🤖 Generated with [Claude Code](https://claude.ai/code)