### PR TITLE
Fix subtitlesData availability in client script

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -329,7 +329,7 @@ const subtitleHTML = renderSubtitleHTML(selectedSubtitle);
 
     // Client-side subtitle randomization
     function randomizeSubtitle() {
-      const subtitles = JSON.parse(`{JSON.stringify(subtitlesData.subtitles)}`);
+      const subtitles = JSON.parse(`${JSON.stringify(subtitlesData.subtitles)}`);
       const randomIndex = Math.floor(Math.random() * subtitles.length);
       const selectedSubtitle = subtitles[randomIndex];
       

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -237,7 +237,7 @@ const subtitleHTML = renderSubtitleHTML(selectedSubtitle);
   </div>
 </header>
 
-<script>
+<script define:vars={{ subtitlesData }}>
   document.addEventListener('DOMContentLoaded', async () => {
     // Check authentication status via API
     let currentUser = null;


### PR DESCRIPTION
## Summary
• Add `define:vars` to pass subtitlesData to client-side JavaScript
• Resolves `ReferenceError: subtitlesData is not defined` in browser
• Enables proper subtitle randomization on deployed site

## Root Cause
The previous fix resolved template literal syntax but subtitlesData was undefined in client-side script. Astro requires explicit variable passing from server to client.

## Test plan
- [x] Verify subtitlesData is available in browser JavaScript
- [x] Confirm subtitle randomization works on each page load
- [x] Test on deployed Cloudflare Workers site

🤖 Generated with [Claude Code](https://claude.ai/code)