### PR TITLE
Fix kebab menu click-outside handler type safety

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -289,8 +289,10 @@ const subtitleHTML = renderSubtitleHTML(selectedSubtitle);
 
       // Close menu when clicking outside
       document.addEventListener('click', (e) => {
-        if (!kebabToggle.contains(e.target as Element) && !kebabDropdown.contains(e.target as Element)) {
-          kebabDropdown.classList.remove('show');
+        if (e.target && e.target instanceof Element) {
+          if (!kebabToggle.contains(e.target) && !kebabDropdown.contains(e.target)) {
+            kebabDropdown.classList.remove('show');
+          }
         }
       });
 


### PR DESCRIPTION
## Summary
- Fixed TypeScript type safety issue in kebab menu click-outside handler
- Replaced unsafe `e.target as Element` assertion with proper type guards
- Prevents runtime errors when `e.target` is null or not an Element

## Root Cause
The original code used `e.target as Element` which could cause runtime errors if `e.target` was null or not an Element object, breaking the kebab menu functionality.

## Solution
Added proper type guards:
```typescript
if (e.target && e.target instanceof Element) {
  if (\!kebabToggle.contains(e.target) && \!kebabDropdown.contains(e.target)) {
    kebabDropdown.classList.remove('show');
  }
}
```

## Test Plan
- [x] Kebab menu opens on click
- [x] Kebab menu closes when clicking outside
- [x] No JavaScript runtime errors in console
- [x] Works in both local and deployed environments

🤖 Generated with [Claude Code](https://claude.ai/code)