### PR TITLE
📝(thoughts): Add Claude Code reviewing itself thought

### DIFF
--- a/src/data/thoughts/published/20250704-claude-reviewing-itself.md
+++ b/src/data/thoughts/published/20250704-claude-reviewing-itself.md
@@ -1,0 +1,11 @@
+---
+content: |
+    Claude Code reviewing its own pull requests be like
+publishDate: 4 Jul 2025
+publishTime: "8:44 AM"
+tags: ["ai", "claude", "obama"]
+color: "#3b82f6"
+images: [
+  { "url": "/assets/thoughts/obama.png", offset: "10%" },
+]
+---


### PR DESCRIPTION
## Issue

- resolve: Add new thought post about Claude Code reviewing its own pull requests

## Why is this change needed?
Adding a simple thought post about the meta concept of Claude Code reviewing its own PRs, with an accompanying image asset.

## What would you like reviewers to focus on?
- Simple markdown thought file with appropriate metadata
- Image asset placement in public/assets/thoughts/
- Minimal content addition without affecting other features

## Testing Verification
- Verified markdown file has correct frontmatter structure
- Confirmed image asset is properly placed
- No conflicts with existing thought system

## What was done
pr_agent:summary

## Detailed Changes
pr_agent:walkthrough

## Additional Notes
This is a standalone addition that was separated from the museum redesign work to keep changes focused and atomic.