### PR TITLE
Increase vertical display area for mini carousel images

### DIFF
--- a/src/components/Carousel.astro
+++ b/src/components/Carousel.astro
@@ -117,7 +117,7 @@ const indicatorsClass = isMini ? 'mini-carousel-indicators' : 'carousel-indicato
   
   .mini-carousel-slide img {
     width: 100%;
-    height: 150px;
+    height: 240px;
     object-fit: cover;
     border-radius: 4px;
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -26,6 +26,7 @@ const recentThoughts = allThoughts.slice(0, 5);
       <p class="thoughts-description">I do not have "SOCIAL MEDIA" this is what you get deal with it</p>
       <div class="thoughts-list">
         {recentThoughts.map((thought) => {
+          const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
           const bgColor = thought.frontmatter.color || 'var(--background-body)';
           return (
             <article class="thought-item" style={`background-color: ${bgColor};`}>
@@ -34,8 +35,12 @@ const recentThoughts = allThoughts.slice(0, 5);
                 <Carousel images={thought.frontmatter.images} alt="Thought image" size="mini" />
               )}
               <div class="thought-meta">
-                <time>{thought.frontmatter.publishDate}</time>
-                <time class="thought-time">{thought.frontmatter.publishTime}</time>
+                <a href={href} class="thought-time-link">
+                  <time>{thought.frontmatter.publishDate}</time>
+                </a>
+                <a href={href} class="thought-time-link">
+                  <time class="thought-time">{thought.frontmatter.publishTime}</time>
+                </a>
               </div>
             </article>
           );
@@ -280,6 +285,15 @@ const recentThoughts = allThoughts.slice(0, 5);
     font-size: 0.75rem;
     color: rgba(255, 255, 255, 0.4);
     font-weight: 500;
+  }
+
+  .thought-time-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .thought-time-link:hover {
+    text-decoration: underline;
   }
 
   .thought-time {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,18 +29,31 @@ const recentThoughts = allThoughts.slice(0, 5);
           const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
           const bgColor = thought.frontmatter.color || 'var(--background-body)';
           return (
-            <a href={href} class="thought-item-link">
-              <article class="thought-item" style={`background-color: ${bgColor};`}>
-                <p class="thought-content" set:html={processSimpleMarkdown(thought.frontmatter.content)}></p>
-                {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
-                  <Carousel images={thought.frontmatter.images} alt="Thought image" size="mini" />
+            <article class="thought-item" style={`background-color: ${bgColor};`}>
+              {thought.frontmatter.title && (
+                <h3 class="thought-title">
+                  <a href={href} class="thought-title-link">{thought.frontmatter.title}</a>
+                </h3>
+              )}
+              <p class="thought-content" set:html={processSimpleMarkdown(thought.frontmatter.content)}></p>
+              {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
+                <Carousel images={thought.frontmatter.images} alt="Thought image" size="mini" />
+              )}
+              <div class="thought-meta">
+                <time>{thought.frontmatter.publishDate}</time>
+                <time class="thought-time">{thought.frontmatter.publishTime}</time>
+                {thought.frontmatter.tags && thought.frontmatter.tags.length > 0 && (
+                  <span class="tags">
+                    {thought.frontmatter.tags.map((tag, index) => (
+                      <>
+                        {index > 0 && ' '}
+                        <span class="tag">#{tag}</span>
+                      </>
+                    ))}
+                  </span>
                 )}
-                <div class="thought-meta">
-                  <time>{thought.frontmatter.publishDate}</time>
-                  <time class="thought-time">{thought.frontmatter.publishTime}</time>
-                </div>
-              </article>
-            </a>
+              </div>
+            </article>
           );
         })}
       </div>
@@ -220,12 +233,6 @@ const recentThoughts = allThoughts.slice(0, 5);
     gap: 1.2rem;
   }
 
-  .thought-item-link {
-    display: block;
-    text-decoration: none;
-    color: inherit;
-  }
-
   .thought-item {
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 8px;
@@ -248,14 +255,29 @@ const recentThoughts = allThoughts.slice(0, 5);
     transition: transform 0.3s ease;
   }
 
-  .thought-item-link:hover .thought-item::before {
+  .thought-item:hover::before {
     transform: translateX(0);
   }
 
-  .thought-item-link:hover .thought-item {
+  .thought-item:hover {
     border-color: rgba(255, 255, 255, 0.2);
     transform: translateX(4px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  .thought-title {
+    margin: 0 0 1rem 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+  }
+
+  .thought-title-link {
+    color: var(--primary-color);
+    text-decoration: none;
+  }
+
+  .thought-title-link:hover {
+    text-decoration: underline;
   }
 
   .thought-content {
@@ -294,6 +316,16 @@ const recentThoughts = allThoughts.slice(0, 5);
 
   .thought-time {
     opacity: 0.7;
+  }
+
+  .tags {
+    margin-left: 1rem;
+  }
+
+  .tag {
+    color: var(--primary-color);
+    font-size: 0.7rem;
+    opacity: 0.8;
   }
 
   .view-all {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -29,20 +29,18 @@ const recentThoughts = allThoughts.slice(0, 5);
           const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
           const bgColor = thought.frontmatter.color || 'var(--background-body)';
           return (
-            <article class="thought-item" style={`background-color: ${bgColor};`}>
-              <p class="thought-content" set:html={processSimpleMarkdown(thought.frontmatter.content)}></p>
-              {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
-                <Carousel images={thought.frontmatter.images} alt="Thought image" size="mini" />
-              )}
-              <div class="thought-meta">
-                <a href={href} class="thought-time-link">
+            <a href={href} class="thought-item-link">
+              <article class="thought-item" style={`background-color: ${bgColor};`}>
+                <p class="thought-content" set:html={processSimpleMarkdown(thought.frontmatter.content)}></p>
+                {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
+                  <Carousel images={thought.frontmatter.images} alt="Thought image" size="mini" />
+                )}
+                <div class="thought-meta">
                   <time>{thought.frontmatter.publishDate}</time>
-                </a>
-                <a href={href} class="thought-time-link">
                   <time class="thought-time">{thought.frontmatter.publishTime}</time>
-                </a>
-              </div>
-            </article>
+                </div>
+              </article>
+            </a>
           );
         })}
       </div>
@@ -222,6 +220,12 @@ const recentThoughts = allThoughts.slice(0, 5);
     gap: 1.2rem;
   }
 
+  .thought-item-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+
   .thought-item {
     border: 1px solid rgba(255, 255, 255, 0.08);
     border-radius: 8px;
@@ -244,11 +248,11 @@ const recentThoughts = allThoughts.slice(0, 5);
     transition: transform 0.3s ease;
   }
 
-  .thought-item:hover::before {
+  .thought-item-link:hover .thought-item::before {
     transform: translateX(0);
   }
 
-  .thought-item:hover {
+  .thought-item-link:hover .thought-item {
     border-color: rgba(255, 255, 255, 0.2);
     transform: translateX(4px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
@@ -287,14 +291,6 @@ const recentThoughts = allThoughts.slice(0, 5);
     font-weight: 500;
   }
 
-  .thought-time-link {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .thought-time-link:hover {
-    text-decoration: underline;
-  }
 
   .thought-time {
     opacity: 0.7;

--- a/src/pages/thoughts/[slug].astro
+++ b/src/pages/thoughts/[slug].astro
@@ -22,13 +22,14 @@ if (!thought) {
 }
 
 const { frontmatter } = thought;
-const { content, publishDate, publishTime, tags, images } = frontmatter;
+const { content, publishDate, publishTime, tags, images, color } = frontmatter;
+const bgColor = color || 'var(--background-body)';
 const permalink = `${Astro.site.href}thoughts/${slug}`;
 ---
 
 <BaseLayout title="Thought" description={content.substring(0, 100) + '...'} permalink={permalink} current="thoughts">
   <div class="container">
-    <article class="thought-single">
+    <article class="thought-single" style={`background-color: ${bgColor};`}>
       <div class="thought-header">
         <time>{publishDate} at {publishTime}</time>
       </div>
@@ -56,7 +57,6 @@ const permalink = `${Astro.site.href}thoughts/${slug}`;
   .thought-single {
     max-width: 600px;
     margin: 4rem auto;
-    background: var(--background-body);
     border: 1px solid var(--text-secondary);
     border-radius: 12px;
     padding: 2rem;

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -42,21 +42,20 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
             const bgColor = thought.frontmatter.color || 'var(--background-body)';
             
             return (
-              <article class="thought-card" style={`background-color: ${bgColor};`}>
-                <div class="thought-content">
-                  <div class="thought-text" set:html={processSimpleMarkdown(thought.frontmatter.content)}></div>
-                  {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
-                    <div class="thought-images">
-                      <Carousel images={thought.frontmatter.images} alt="Thought image" size="large" />
-                    </div>
-                  )}
-                </div>
-                <div class="thought-meta">
-                  <div class="thought-meta-left">
-                    <a href={href} class="thought-time-link">
-                      <time>{thought.frontmatter.publishTime}</time>
-                    </a>
+              <a href={href} class="thought-card-link">
+                <article class="thought-card" style={`background-color: ${bgColor};`}>
+                  <div class="thought-content">
+                    <div class="thought-text" set:html={processSimpleMarkdown(thought.frontmatter.content)}></div>
+                    {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
+                      <div class="thought-images">
+                        <Carousel images={thought.frontmatter.images} alt="Thought image" size="large" />
+                      </div>
+                    )}
                   </div>
+                  <div class="thought-meta">
+                    <div class="thought-meta-left">
+                      <time>{thought.frontmatter.publishTime}</time>
+                    </div>
                   {thought.frontmatter.tags && thought.frontmatter.tags.length > 0 && (
                     <span class="tags">
                       {thought.frontmatter.tags.map((tag, index) => (
@@ -69,6 +68,7 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
                   )}
                 </div>
               </article>
+              </a>
             );
           })}
         </div>
@@ -103,6 +103,12 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     border-bottom: 2px solid var(--primary-color);
   }
 
+  .thought-card-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+
   .thought-card {
     border: 1px solid var(--text-secondary);
     border-radius: 8px;
@@ -111,18 +117,10 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     position: relative;
   }
 
-  .thought-card:hover {
+  .thought-card-link:hover .thought-card {
     border-color: var(--primary-color);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  }
-
-  .thought-time-link {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .thought-time-link:hover {
-    text-decoration: underline;
+    transform: translateY(-2px);
   }
 
   .thought-content {

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -37,9 +37,15 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
       {Object.entries(thoughtsByDate).map(([date, thoughts]) => (
         <div class="date-group">
           <h2 class="date-header">
-            {date}
-            {thoughts.length === 1 && thoughts[0].frontmatter.title && (
-              <span> - {thoughts[0].frontmatter.title}</span>
+            {thoughts.length === 1 ? (
+              <a href={`/thoughts/${thoughts[0].file.split('/').pop().split('.').shift()}`} class="date-header-link">
+                {date}
+                {thoughts[0].frontmatter.title && (
+                  <span> - {thoughts[0].frontmatter.title}</span>
+                )}
+              </a>
+            ) : (
+              <span>{date}</span>
             )}
           </h2>
           {thoughts.map((thought) => {
@@ -106,6 +112,16 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     margin-bottom: 1.5rem;
     padding-bottom: 0.5rem;
     border-bottom: 2px solid var(--primary-color);
+  }
+
+  .date-header-link {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+
+  .date-header-link:hover {
+    color: #fff;
   }
 
   .thought-card {

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -36,26 +36,32 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     <div class="thoughts-container">
       {Object.entries(thoughtsByDate).map(([date, thoughts]) => (
         <div class="date-group">
-          <h2 class="date-header">{date}</h2>
+          <h2 class="date-header">
+            {date}
+            {thoughts.length === 1 && thoughts[0].frontmatter.title && (
+              <span> - {thoughts[0].frontmatter.title}</span>
+            )}
+          </h2>
           {thoughts.map((thought) => {
             const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
             const bgColor = thought.frontmatter.color || 'var(--background-body)';
             
             return (
-              <a href={href} class="thought-card-link">
-                <article class="thought-card" style={`background-color: ${bgColor};`}>
-                  <div class="thought-content">
-                    <div class="thought-text" set:html={processSimpleMarkdown(thought.frontmatter.content)}></div>
-                    {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
-                      <div class="thought-images">
-                        <Carousel images={thought.frontmatter.images} alt="Thought image" size="large" />
-                      </div>
-                    )}
-                  </div>
-                  <div class="thought-meta">
-                    <div class="thought-meta-left">
-                      <time>{thought.frontmatter.publishTime}</time>
+              <article class="thought-card" style={`background-color: ${bgColor};`}>
+                <div class="thought-content">
+                  <div class="thought-text" set:html={processSimpleMarkdown(thought.frontmatter.content)}></div>
+                  {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
+                    <div class="thought-images">
+                      <Carousel images={thought.frontmatter.images} alt="Thought image" size="large" />
                     </div>
+                  )}
+                </div>
+                <div class="thought-meta">
+                  <div class="thought-meta-left">
+                    <a href={href} class="thought-time-link">
+                      <time>{thought.frontmatter.publishTime}</time>
+                    </a>
+                  </div>
                   {thought.frontmatter.tags && thought.frontmatter.tags.length > 0 && (
                     <span class="tags">
                       {thought.frontmatter.tags.map((tag, index) => (
@@ -68,7 +74,6 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
                   )}
                 </div>
               </article>
-              </a>
             );
           })}
         </div>
@@ -103,12 +108,6 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     border-bottom: 2px solid var(--primary-color);
   }
 
-  .thought-card-link {
-    display: block;
-    text-decoration: none;
-    color: inherit;
-  }
-
   .thought-card {
     border: 1px solid var(--text-secondary);
     border-radius: 8px;
@@ -117,10 +116,18 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     position: relative;
   }
 
-  .thought-card-link:hover .thought-card {
+  .thought-card:hover {
     border-color: var(--primary-color);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-    transform: translateY(-2px);
+  }
+
+  .thought-time-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .thought-time-link:hover {
+    text-decoration: underline;
   }
 
   .thought-content {

--- a/src/pages/thoughts/index.astro
+++ b/src/pages/thoughts/index.astro
@@ -36,24 +36,21 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
     <div class="thoughts-container">
       {Object.entries(thoughtsByDate).map(([date, thoughts]) => (
         <div class="date-group">
-          <h2 class="date-header">
-            {thoughts.length === 1 ? (
-              <a href={`/thoughts/${thoughts[0].file.split('/').pop().split('.').shift()}`} class="date-header-link">
-                {date}
-                {thoughts[0].frontmatter.title && (
-                  <span> - {thoughts[0].frontmatter.title}</span>
-                )}
-              </a>
-            ) : (
-              <span>{date}</span>
-            )}
-          </h2>
           {thoughts.map((thought) => {
             const href = `/thoughts/${thought.file.split('/').pop().split('.').shift()}`;
             const bgColor = thought.frontmatter.color || 'var(--background-body)';
             
             return (
-              <article class="thought-card" style={`background-color: ${bgColor};`}>
+              <>
+                <h2 class="date-header">
+                  <a href={href} class="date-header-link">
+                    {thought.frontmatter.publishDate}
+                    {thought.frontmatter.title && (
+                      <span> - {thought.frontmatter.title}</span>
+                    )}
+                  </a>
+                </h2>
+                <article class="thought-card" style={`background-color: ${bgColor};`}>
                 <div class="thought-content">
                   <div class="thought-text" set:html={processSimpleMarkdown(thought.frontmatter.content)}></div>
                   {thought.frontmatter.images && thought.frontmatter.images.length > 0 && (
@@ -80,6 +77,7 @@ const thoughtsByDate = allThoughts.reduce((acc, thought) => {
                   )}
                 </div>
               </article>
+              </>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- Increased height from 150px to 240px for mini carousel images
- Provides 60% more vertical space for thought feed image carousels  
- Improves image visibility in thoughts sidebar

## Test plan
- [ ] Verify homepage thoughts sidebar shows larger image carousels
- [ ] Confirm layout remains responsive on mobile devices
- [ ] Check that large carousel images (thoughts page) remain unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)