### PR TITLE
Add interactive biography difficulty selector

### DIFF
--- a/.kiro/specs/biography-difficulty-selector/design.md
+++ b/.kiro/specs/biography-difficulty-selector/design.md
@@ -1,0 +1,201 @@
+# Design Document
+
+## Overview
+
+The biography difficulty selector will transform the current single-biography experience into an interactive, multi-level content system. Users will be able to choose from five difficulty levels, each providing progressively more detailed biographical information. The system will integrate seamlessly with the existing Astro-based architecture while maintaining the site's aesthetic and performance characteristics.
+
+## Architecture
+
+### Component Structure
+
+The system will consist of three main components:
+
+1. **BiographyDifficultySelector**: A new interactive component that renders the difficulty selection interface
+2. **BiographyContent**: A new component that manages and displays content based on selected difficulty
+3. **Enhanced Bio Component**: The existing Bio.astro component will be updated to integrate the new functionality
+
+### Data Flow
+
+```mermaid
+graph TD
+    A[User selects difficulty] --> B[Update local storage]
+    B --> C[Trigger content update]
+    C --> D[BiographyContent component]
+    D --> E[Render appropriate content]
+    E --> F[Apply smooth transition]
+    
+    G[Page load] --> H[Check local storage]
+    H --> I{Stored preference?}
+    I -->|Yes| J[Load stored difficulty]
+    I -->|No| K[Default to Normal]
+    J --> D
+    K --> D
+```
+
+## Components and Interfaces
+
+### BiographyDifficultySelector Component
+
+**Location**: `src/components/BiographyDifficultySelector.astro`
+
+**Props Interface**:
+```typescript
+interface DifficultyLevel {
+  id: string;
+  name: string;
+  description: string;
+}
+
+interface Props {
+  levels: DifficultyLevel[];
+  defaultLevel?: string;
+  onLevelChange?: (level: string) => void;
+}
+```
+
+**Functionality**:
+- Renders five difficulty buttons with distinct visual styling
+- Manages active state and hover effects
+- Handles click events and local storage updates
+- Provides tooltips with difficulty descriptions
+
+### BiographyContent Component
+
+**Location**: `src/components/BiographyContent.astro`
+
+**Props Interface**:
+```typescript
+interface BiographyData {
+  tutorial: string;
+  storyMode: string;
+  normal: string;
+  hard: string;
+  maddening: string;
+}
+
+interface Props {
+  content: BiographyData;
+  currentLevel: string;
+}
+```
+
+**Functionality**:
+- Stores all difficulty-level content
+- Renders content based on selected difficulty
+- Handles content transitions and animations
+- Provides fallback content for missing levels
+
+### Enhanced Bio Component
+
+**Location**: `src/components/Bio.astro` (modified)
+
+**Changes**:
+- Integrate BiographyDifficultySelector and BiographyContent
+- Maintain existing styling and layout structure
+- Add client-side JavaScript for interactivity
+
+## Data Models
+
+### Difficulty Levels Configuration
+
+```typescript
+const DIFFICULTY_LEVELS: DifficultyLevel[] = [
+  {
+    id: 'tutorial',
+    name: 'Tutorial',
+    description: 'Basic facts and essential information'
+  },
+  {
+    id: 'story-mode',
+    name: 'Story Mode',
+    description: 'Key life events and background'
+  },
+  {
+    id: 'normal',
+    name: 'Normal',
+    description: 'Balanced overview with personality'
+  },
+  {
+    id: 'hard',
+    name: 'Hard',
+    description: 'Detailed stories and insights'
+  },
+  {
+    id: 'maddening',
+    name: 'Maddening',
+    description: 'Complete unfiltered biography'
+  }
+];
+```
+
+### Content Structure
+
+The biography content will be structured as a TypeScript object with keys for each difficulty level:
+
+```typescript
+const biographyContent = {
+  tutorial: "Basic facts about Emily...",
+  storyMode: "Key life events...",
+  normal: "Balanced biographical overview...",
+  hard: "Detailed personal stories...",
+  maddening: "The current full biography content..."
+};
+```
+
+## Error Handling
+
+### Content Fallbacks
+
+1. **Missing Content**: If content for a selected difficulty is unavailable, fall back to the next available level in this order: Normal → Story Mode → Tutorial
+2. **JavaScript Disabled**: Gracefully degrade to show Normal difficulty content without the selector
+3. **Local Storage Issues**: If local storage is unavailable, use session-based state management
+
+### User Experience Safeguards
+
+1. **Loading States**: Show subtle loading indicators during content transitions
+2. **Smooth Transitions**: Use CSS transitions to prevent jarring content changes
+3. **Responsive Design**: Ensure selector works on all device sizes
+4. **Accessibility**: Provide keyboard navigation and screen reader support
+
+## Testing Strategy
+
+### Unit Tests
+
+1. **Component Rendering**: Test that all difficulty levels render correctly
+2. **State Management**: Verify local storage persistence and retrieval
+3. **Content Switching**: Ensure content updates match selected difficulty
+4. **Fallback Behavior**: Test graceful degradation scenarios
+
+### Integration Tests
+
+1. **User Interactions**: Test complete user flow from selection to content display
+2. **Cross-Browser Compatibility**: Verify functionality across major browsers
+3. **Mobile Responsiveness**: Test touch interactions and layout on mobile devices
+4. **Performance**: Ensure content switching is smooth and responsive
+
+### Accessibility Tests
+
+1. **Keyboard Navigation**: Verify all functionality is accessible via keyboard
+2. **Screen Reader Support**: Test with screen readers for proper announcements
+3. **Color Contrast**: Ensure difficulty selector meets WCAG guidelines
+4. **Focus Management**: Verify proper focus handling during interactions
+
+## Implementation Considerations
+
+### Performance Optimization
+
+- **Content Preloading**: All difficulty content will be loaded initially to enable instant switching
+- **CSS Transitions**: Use hardware-accelerated CSS transitions for smooth animations
+- **Minimal JavaScript**: Keep client-side JavaScript lightweight and efficient
+
+### Styling Integration
+
+- **Consistent Design**: Match existing site aesthetics and color scheme
+- **Visual Hierarchy**: Use progressive visual complexity to suggest difficulty levels
+- **Responsive Layout**: Ensure selector adapts to different screen sizes
+
+### Future Extensibility
+
+- **Content Management**: Design content structure to easily accommodate new difficulty levels
+- **Reusability**: Create components that could be reused for other content types
+- **Analytics Integration**: Prepare hooks for tracking difficulty level preferences

--- a/.kiro/specs/biography-difficulty-selector/requirements.md
+++ b/.kiro/specs/biography-difficulty-selector/requirements.md
@@ -1,0 +1,51 @@
+# Requirements Document
+
+## Introduction
+
+This feature adds an interactive difficulty selector to the biography section of the personal website, allowing users to choose between different levels of biographical detail. The system will provide five difficulty levels ranging from basic facts (Tutorial) to comprehensive detail (Maddening), giving users control over how much information they want to consume.
+
+## Requirements
+
+### Requirement 1
+
+**User Story:** As a website visitor, I want to select different difficulty levels for the biography content, so that I can choose the amount of detail that matches my interest level.
+
+#### Acceptance Criteria
+
+1. WHEN a user visits the biography page THEN the system SHALL display a difficulty selector with five options: "Tutorial", "Story Mode", "Normal", "Hard", and "Maddening"
+2. WHEN a user selects a difficulty level THEN the system SHALL immediately update the displayed biography content to match the selected difficulty
+3. WHEN a user refreshes the page THEN the system SHALL remember their last selected difficulty level using local storage
+4. WHEN no difficulty has been previously selected THEN the system SHALL default to "Normal" difficulty
+
+### Requirement 2
+
+**User Story:** As a website visitor, I want the difficulty selector to be visually intuitive and engaging, so that I understand what each level represents and am encouraged to explore different options.
+
+#### Acceptance Criteria
+
+1. WHEN the difficulty selector is displayed THEN each difficulty level SHALL have a distinct visual style that suggests its complexity level
+2. WHEN a user hovers over a difficulty option THEN the system SHALL provide a brief tooltip or description of what that level contains
+3. WHEN a difficulty level is selected THEN the system SHALL provide clear visual feedback showing which level is currently active
+4. WHEN the biography content changes THEN the system SHALL use smooth transitions to avoid jarring content switches
+
+### Requirement 3
+
+**User Story:** As the website owner, I want to easily manage different biography content for each difficulty level, so that I can update and maintain the content without complex technical changes.
+
+#### Acceptance Criteria
+
+1. WHEN implementing the system THEN each difficulty level SHALL have its own clearly defined content structure
+2. WHEN content needs to be updated THEN the system SHALL allow easy modification of individual difficulty levels without affecting others
+3. WHEN a new difficulty level is added THEN the system SHALL gracefully handle the addition without breaking existing functionality
+4. WHEN content is missing for a difficulty level THEN the system SHALL fall back to a default message or the next available level
+
+### Requirement 4
+
+**User Story:** As a website visitor, I want the biography difficulty selector to work seamlessly across different devices and browsers, so that I have a consistent experience regardless of how I access the site.
+
+#### Acceptance Criteria
+
+1. WHEN accessing the biography on mobile devices THEN the difficulty selector SHALL be fully functional and appropriately sized for touch interaction
+2. WHEN using different browsers THEN the difficulty selector SHALL maintain consistent functionality and appearance
+3. WHEN JavaScript is disabled THEN the system SHALL gracefully degrade to show the default biography content
+4. WHEN the page loads THEN the difficulty selector SHALL be immediately interactive without requiring additional loading time

--- a/.kiro/specs/biography-difficulty-selector/tasks.md
+++ b/.kiro/specs/biography-difficulty-selector/tasks.md
@@ -1,0 +1,70 @@
+# Implementation Plan
+
+- [ ] 1. Create core data structure and content management
+  - Define TypeScript interfaces for difficulty levels and biography content
+  - Create biography content object with placeholder content for all five difficulty levels
+  - Set up content structure that will hold the current "Maddening" content and placeholders for other levels
+  - _Requirements: 3.1, 3.2_
+
+- [ ] 2. Build BiographyDifficultySelector component
+  - Create new Astro component for the difficulty selector interface
+  - Implement five difficulty level buttons with distinct visual styling
+  - Add hover effects and active state management
+  - Include tooltip functionality for difficulty descriptions
+  - _Requirements: 1.1, 2.1, 2.2, 2.3_
+
+- [ ] 3. Implement BiographyContent component
+  - Create component to manage and display content based on selected difficulty
+  - Add smooth CSS transitions for content switching
+  - Implement fallback logic for missing content levels
+  - Ensure content renders with proper formatting and styling
+  - _Requirements: 1.2, 2.4, 3.3_
+
+- [ ] 4. Add client-side state management
+  - Implement JavaScript for difficulty selection handling
+  - Add local storage persistence for user preferences
+  - Create state management for active difficulty level
+  - Handle page load initialization with stored or default preferences
+  - _Requirements: 1.3, 1.4_
+
+- [ ] 5. Integrate components into existing Bio component
+  - Modify existing Bio.astro to include new difficulty selector and content components
+  - Maintain existing styling and layout structure
+  - Ensure seamless integration with current bio page design
+  - Test component integration and functionality
+  - _Requirements: 1.1, 1.2_
+
+- [ ] 6. Implement responsive design and accessibility
+  - Add responsive CSS for mobile and tablet devices
+  - Implement keyboard navigation support
+  - Add ARIA labels and screen reader support
+  - Ensure touch-friendly interactions on mobile devices
+  - _Requirements: 4.1, 4.2_
+
+- [ ] 7. Add graceful degradation and error handling
+  - Implement fallback behavior when JavaScript is disabled
+  - Add error handling for local storage issues
+  - Create fallback content loading for missing difficulty levels
+  - Test cross-browser compatibility
+  - _Requirements: 4.3, 4.4, 3.4_
+
+- [ ] 8. Create comprehensive test suite
+  - Write unit tests for component rendering and state management
+  - Add integration tests for user interaction flows
+  - Test local storage persistence and retrieval
+  - Verify accessibility compliance and keyboard navigation
+  - _Requirements: 1.1, 1.2, 1.3, 2.1, 2.2, 2.3, 4.1, 4.2_
+
+- [ ] 9. Populate content for all difficulty levels
+  - Move current biography content to "Maddening" level
+  - Create "Tutorial" level with basic facts placeholder
+  - Add placeholder content structure for "Story Mode", "Normal", and "Hard" levels
+  - Ensure content formatting is consistent across all levels
+  - _Requirements: 3.1, 3.2_
+
+- [ ] 10. Final integration and polish
+  - Integrate all components into the bio page
+  - Apply final styling and visual polish
+  - Test complete user experience flow
+  - Verify performance and smooth transitions
+  - _Requirements: 1.1, 1.2, 2.4, 4.4_

--- a/src/components/Bio.astro
+++ b/src/components/Bio.astro
@@ -1,57 +1,188 @@
+---
+import BiographyDifficultySelector from './BiographyDifficultySelector.astro';
+import BiographyContent from './BiographyContent.astro';
+import { DEFAULT_DIFFICULTY } from '../data/biography-difficulty';
+---
+
 <div class="bio-container">
-  <div class="bio-content">
-    <img src="/assets/portrait_square.png" alt="The Authoress">
-    <p>
-      Hello! I'm <strong>Emily</strong>, an engineering type just trying to have a good time. GOD FORBID.
-      Check out my <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> or
-      <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>, I guess.
-    </p>
-  </div>
+  <BiographyDifficultySelector defaultLevel={DEFAULT_DIFFICULTY} />
+  <BiographyContent currentLevel={DEFAULT_DIFFICULTY} />
 </div>
+
+<script>
+  class BiographyDifficultyManager {
+    private currentDifficulty: string;
+    private buttons: NodeListOf<HTMLButtonElement>;
+    private textElements: NodeListOf<HTMLParagraphElement>;
+    private readonly STORAGE_KEY = 'biography-difficulty';
+
+    constructor() {
+      this.currentDifficulty = 'normal'; // Default difficulty
+      this.buttons = document.querySelectorAll('.difficulty-btn');
+      this.textElements = document.querySelectorAll('[data-difficulty-content]');
+      
+      this.init();
+    }
+
+    private init() {
+      // Load saved preference from localStorage first
+      const savedDifficulty = this.loadSavedDifficulty();
+      if (savedDifficulty) {
+        this.currentDifficulty = savedDifficulty;
+      }
+      
+      // Set initial active states
+      this.updateDisplay();
+      
+      // Add click handlers to buttons
+      this.buttons.forEach(button => {
+        button.addEventListener('click', (e) => {
+          const target = e.currentTarget as HTMLButtonElement;
+          const difficultyId = target.dataset.difficulty;
+          if (difficultyId) {
+            this.setDifficulty(difficultyId);
+          }
+        });
+
+        // Add keyboard support
+        button.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            button.click();
+          }
+        });
+      });
+    }
+
+    private loadSavedDifficulty(): string | null {
+      try {
+        return localStorage.getItem(this.STORAGE_KEY);
+      } catch (error) {
+        console.warn('Failed to load difficulty preference from localStorage:', error);
+        return null;
+      }
+    }
+
+    private saveDifficulty(difficulty: string): void {
+      try {
+        localStorage.setItem(this.STORAGE_KEY, difficulty);
+      } catch (error) {
+        console.warn('Failed to save difficulty preference to localStorage:', error);
+      }
+    }
+
+    private setDifficulty(difficultyId: string) {
+      this.currentDifficulty = difficultyId;
+      this.updateDisplay();
+      this.saveDifficulty(difficultyId);
+      
+      // Trigger custom event for potential analytics/tracking
+      window.dispatchEvent(new CustomEvent('biography-difficulty-changed', {
+        detail: { difficulty: difficultyId }
+      }));
+    }
+
+    private updateDisplay() {
+      // Update button states
+      this.buttons.forEach(button => {
+        const isActive = button.dataset.difficulty === this.currentDifficulty;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive.toString());
+      });
+
+      // Update text visibility with smooth transitions
+      this.textElements.forEach(element => {
+        const isVisible = element.dataset.difficultyContent === this.currentDifficulty;
+        
+        if (isVisible) {
+          // Show the active content
+          element.style.display = 'block';
+          element.classList.add('active');
+          element.classList.add('fade-in');
+          element.classList.remove('fade-out');
+          
+          // Remove absolute positioning for active element
+          element.style.position = 'relative';
+        } else {
+          // Hide inactive content
+          element.classList.remove('active', 'fade-in');
+          element.classList.add('fade-out');
+          element.style.position = 'absolute';
+          
+          // Hide after transition
+          setTimeout(() => {
+            if (!element.classList.contains('active')) {
+              element.style.display = 'none';
+            }
+          }, 300);
+        }
+      });
+    }
+
+    // Fallback method for when content is missing
+    private getFallbackContent(): string {
+      const fallbackOrder = ['normal', 'story-mode', 'tutorial'];
+      
+      for (const difficulty of fallbackOrder) {
+        const element = document.querySelector(`[data-difficulty-content="${difficulty}"]`);
+        if (element) {
+          return difficulty;
+        }
+      }
+      
+      return 'normal'; // Ultimate fallback
+    }
+  }
+
+  // Initialize when DOM is ready
+  function initializeBiographyDifficulty() {
+    if (document.querySelector('.difficulty-btn')) {
+      new BiographyDifficultyManager();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeBiographyDifficulty);
+  } else {
+    initializeBiographyDifficulty();
+  }
+
+  // Graceful degradation: if JavaScript fails, show normal difficulty
+  window.addEventListener('error', () => {
+    const normalContent = document.querySelector('[data-difficulty-content="normal"]') as HTMLElement;
+    if (normalContent) {
+      normalContent.style.display = 'block';
+      normalContent.style.position = 'relative';
+      normalContent.classList.add('active');
+    }
+  });
+</script>
+
+<!-- Fallback for when JavaScript is disabled -->
+<noscript>
+  <style>
+    [data-difficulty-content]:not([data-difficulty-content="normal"]) {
+      display: none !important;
+    }
+    [data-difficulty-content="normal"] {
+      display: block !important;
+      position: relative !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+    .difficulty-selector {
+      display: none !important;
+    }
+  </style>
+</noscript>
 
 <style>
   .bio-container {
     display: flex;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     padding: 2rem 1rem;
     margin-top: 3rem;
-  }
-
-  .bio-content {
-    display: flex;
-    align-items: center;
-    width: 600px;
-    max-width: 90vw;
-    background: #1a1a1a;
-    padding: 2rem;
-    border-radius: 12px;
-    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
-    border: 1px solid #333;
-  }
-
-  img {
-    width: 100px;
-    height: 100px;
-    border-radius: 50%;
-    display: block;
-    margin-right: 20px;
-    flex-shrink: 0;
-  }
-
-  p {
-    font-size: 1.125rem;
-    margin: 0;
-    line-height: 1.6;
-    color: #e0e0e0;
-  }
-
-  a {
-    color: #66b3ff;
-    text-decoration: none;
-  }
-
-  a:hover {
-    color: #99ccff;
-    text-decoration: underline;
+    gap: 1.5rem;
   }
 </style>

--- a/src/components/BioWithFlavors.astro
+++ b/src/components/BioWithFlavors.astro
@@ -1,0 +1,296 @@
+---
+import { bioFlavors, defaultFlavorId } from '../data/bio-flavors';
+---
+
+<div class="bio-container">
+  <div class="flavor-selector">
+    <span class="flavor-label">Bio Flavor:</span>
+    <div class="flavor-buttons">
+      {bioFlavors.map((flavor) => (
+        <button 
+          class="flavor-btn" 
+          data-flavor={flavor.id}
+          title={flavor.description}
+          aria-label={`Switch to ${flavor.name} bio flavor`}
+        >
+          <span class="flavor-emoji">{flavor.emoji}</span>
+          <span class="flavor-name">{flavor.name}</span>
+        </button>
+      ))}
+    </div>
+  </div>
+
+  <div class="bio-content">
+    <img src="/assets/portrait_square.png" alt="The Authoress" class="bio-image">
+    <div class="bio-text-container">
+      {bioFlavors.map((flavor) => (
+        <p 
+          class="bio-text" 
+          data-flavor-content={flavor.id}
+          set:html={flavor.content}
+        />
+      ))}
+    </div>
+  </div>
+</div>
+
+<script>
+  class BioFlavorManager {
+    private currentFlavor: string;
+    private buttons: NodeListOf<HTMLButtonElement>;
+    private textElements: NodeListOf<HTMLParagraphElement>;
+
+    constructor() {
+      this.currentFlavor = 'casual'; // Default flavor
+      this.buttons = document.querySelectorAll('.flavor-btn');
+      this.textElements = document.querySelectorAll('[data-flavor-content]');
+      
+      this.init();
+    }
+
+    private init() {
+      // Set initial active states
+      this.updateDisplay();
+      
+      // Add click handlers to buttons
+      this.buttons.forEach(button => {
+        button.addEventListener('click', (e) => {
+          const target = e.currentTarget as HTMLButtonElement;
+          const flavorId = target.dataset.flavor;
+          if (flavorId) {
+            this.setFlavor(flavorId);
+          }
+        });
+      });
+
+      // Load saved preference from localStorage
+      const savedFlavor = localStorage.getItem('bio-flavor');
+      if (savedFlavor) {
+        this.setFlavor(savedFlavor);
+      }
+    }
+
+    private setFlavor(flavorId: string) {
+      this.currentFlavor = flavorId;
+      this.updateDisplay();
+      
+      // Save preference
+      localStorage.setItem('bio-flavor', flavorId);
+      
+      // Trigger custom event for analytics/tracking
+      window.dispatchEvent(new CustomEvent('bio-flavor-changed', {
+        detail: { flavor: flavorId }
+      }));
+    }
+
+    private updateDisplay() {
+      // Update button states
+      this.buttons.forEach(button => {
+        const isActive = button.dataset.flavor === this.currentFlavor;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive.toString());
+      });
+
+      // Update text visibility with fade transition
+      this.textElements.forEach(element => {
+        const isVisible = element.dataset.flavorContent === this.currentFlavor;
+        
+        if (isVisible) {
+          element.style.display = 'block';
+          element.classList.add('fade-in');
+          element.classList.remove('fade-out');
+        } else {
+          element.classList.add('fade-out');
+          element.classList.remove('fade-in');
+          
+          // Hide after transition
+          setTimeout(() => {
+            if (!element.classList.contains('fade-in')) {
+              element.style.display = 'none';
+            }
+          }, 200);
+        }
+      });
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => new BioFlavorManager());
+  } else {
+    new BioFlavorManager();
+  }
+</script>
+
+<style>
+  .bio-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 2rem 1rem;
+    margin-top: 3rem;
+    gap: 1.5rem;
+  }
+
+  .flavor-selector {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .flavor-label {
+    font-size: 0.875rem;
+    color: #a0a0a0;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .flavor-buttons {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .flavor-btn {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem;
+    background: #2a2a2a;
+    border: 1px solid #404040;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    min-width: 60px;
+    font-family: inherit;
+  }
+
+  .flavor-btn:hover {
+    background: #333;
+    border-color: #555;
+    transform: translateY(-1px);
+  }
+
+  .flavor-btn.active {
+    background: #3a5a7a;
+    border-color: #66b3ff;
+    box-shadow: 0 0 0 2px rgba(102, 179, 255, 0.2);
+  }
+
+  .flavor-emoji {
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .flavor-name {
+    font-size: 0.75rem;
+    color: #e0e0e0;
+    font-weight: 500;
+  }
+
+  .flavor-btn.active .flavor-name {
+    color: #fff;
+  }
+
+  .bio-content {
+    display: flex;
+    align-items: center;
+    width: 600px;
+    max-width: 90vw;
+    background: #1a1a1a;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+    border: 1px solid #333;
+    position: relative;
+    min-height: 120px;
+  }
+
+  .bio-image {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    display: block;
+    margin-right: 20px;
+    flex-shrink: 0;
+  }
+
+  .bio-text-container {
+    flex: 1;
+    position: relative;
+  }
+
+  .bio-text {
+    font-size: 1.125rem;
+    margin: 0;
+    line-height: 1.6;
+    color: #e0e0e0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    display: none;
+  }
+
+  .bio-text.fade-in {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .bio-text.fade-out {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  .bio-text a {
+    color: #66b3ff;
+    text-decoration: none;
+  }
+
+  .bio-text a:hover {
+    color: #99ccff;
+    text-decoration: underline;
+  }
+
+  /* Mobile responsiveness */
+  @media (max-width: 640px) {
+    .bio-content {
+      flex-direction: column;
+      text-align: center;
+      padding: 1.5rem;
+    }
+
+    .bio-image {
+      margin-right: 0;
+      margin-bottom: 1rem;
+    }
+
+    .flavor-buttons {
+      gap: 0.25rem;
+    }
+
+    .flavor-btn {
+      min-width: 50px;
+      padding: 0.375rem;
+    }
+
+    .flavor-name {
+      font-size: 0.6875rem;
+    }
+  }
+
+  /* Reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .bio-text,
+    .flavor-btn {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/BiographyContent.astro
+++ b/src/components/BiographyContent.astro
@@ -1,0 +1,119 @@
+---
+import { biographyContent, type BiographyData } from '../data/biography-difficulty';
+
+interface Props {
+  currentLevel?: string;
+}
+
+const { currentLevel = 'normal' } = Astro.props;
+---
+
+<div class="biography-content">
+  <img src="/assets/portrait_square.png" alt="The Authoress" class="bio-image">
+  <div class="bio-text-container" aria-live="polite" aria-atomic="true">
+    {Object.entries(biographyContent).map(([level, content]) => (
+      <p 
+        class="bio-text" 
+        data-difficulty-content={level}
+        set:html={content}
+      />
+    ))}
+  </div>
+</div>
+
+<style>
+  .biography-content {
+    display: flex;
+    align-items: center;
+    width: 600px;
+    max-width: 90vw;
+    background: #1a1a1a;
+    padding: 2rem;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.3);
+    border: 1px solid #333;
+    position: relative;
+    min-height: 120px;
+  }
+
+  .bio-image {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    display: block;
+    margin-right: 20px;
+    flex-shrink: 0;
+  }
+
+  .bio-text-container {
+    flex: 1;
+    position: relative;
+  }
+
+  .bio-text {
+    font-size: 1.125rem;
+    margin: 0;
+    line-height: 1.6;
+    color: #e0e0e0;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    opacity: 0;
+    transform: translateY(10px);
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    display: none;
+  }
+
+  .bio-text.active {
+    opacity: 1;
+    transform: translateY(0);
+    display: block;
+    position: relative;
+  }
+
+  .bio-text.fade-in {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .bio-text.fade-out {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  .bio-text a {
+    color: #66b3ff;
+    text-decoration: none;
+  }
+
+  .bio-text a:hover {
+    color: #99ccff;
+    text-decoration: underline;
+  }
+
+  /* Mobile responsiveness */
+  @media (max-width: 640px) {
+    .biography-content {
+      flex-direction: column;
+      text-align: center;
+      padding: 1.5rem;
+    }
+
+    .bio-image {
+      margin-right: 0;
+      margin-bottom: 1rem;
+    }
+
+    .bio-text {
+      font-size: 1rem;
+    }
+  }
+
+  /* Reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .bio-text {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/BiographyDifficultySelector.astro
+++ b/src/components/BiographyDifficultySelector.astro
@@ -1,0 +1,222 @@
+---
+import { DIFFICULTY_LEVELS } from '../data/biography-difficulty';
+
+interface Props {
+  defaultLevel?: string;
+}
+
+const { defaultLevel = 'normal' } = Astro.props;
+---
+
+<div class="difficulty-selector">
+  <div class="selector-header">
+    <span class="selector-label">Biography Difficulty</span>
+  </div>
+  <div class="difficulty-buttons">
+    {DIFFICULTY_LEVELS.map((level) => (
+      <button 
+        class="difficulty-btn" 
+        data-difficulty={level.id}
+        title={level.description}
+        aria-label={`Switch to ${level.name} difficulty level`}
+        aria-pressed="false"
+        role="button"
+        tabindex="0"
+      >
+        <span class="difficulty-name">{level.name}</span>
+      </button>
+    ))}
+  </div>
+</div>
+
+<style>
+  .difficulty-selector {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .selector-header {
+    text-align: center;
+  }
+
+  .selector-label {
+    font-size: 0.875rem;
+    color: #a0a0a0;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }
+
+  .difficulty-buttons {
+    display: flex;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .difficulty-btn {
+    padding: 0.75rem 1rem;
+    background: #2a2a2a;
+    border: 2px solid #404040;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: inherit;
+    font-size: 0.875rem;
+    font-weight: 500;
+    position: relative;
+  }
+
+  /* Progressive visual complexity for difficulty levels */
+  .difficulty-btn[data-difficulty="tutorial"] {
+    background: #2a3a2a;
+    border-color: #4a6a4a;
+    color: #90c090;
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"] {
+    background: #2a2a3a;
+    border-color: #4a4a6a;
+    color: #9090c0;
+  }
+
+  .difficulty-btn[data-difficulty="normal"] {
+    background: #2a2a2a;
+    border-color: #6a6a6a;
+    color: #c0c0c0;
+  }
+
+  .difficulty-btn[data-difficulty="hard"] {
+    background: #3a2a2a;
+    border-color: #6a4a4a;
+    color: #c09090;
+  }
+
+  .difficulty-btn[data-difficulty="maddening"] {
+    background: #3a1a1a;
+    border-color: #6a2a2a;
+    color: #c07070;
+    box-shadow: 0 0 8px rgba(192, 112, 112, 0.2);
+  }
+
+  .difficulty-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="tutorial"]:hover {
+    border-color: #6a8a6a;
+    box-shadow: 0 4px 12px rgba(144, 192, 144, 0.2);
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"]:hover {
+    border-color: #6a6a8a;
+    box-shadow: 0 4px 12px rgba(144, 144, 192, 0.2);
+  }
+
+  .difficulty-btn[data-difficulty="normal"]:hover {
+    border-color: #8a8a8a;
+    box-shadow: 0 4px 12px rgba(192, 192, 192, 0.2);
+  }
+
+  .difficulty-btn[data-difficulty="hard"]:hover {
+    border-color: #8a6a6a;
+    box-shadow: 0 4px 12px rgba(192, 144, 144, 0.2);
+  }
+
+  .difficulty-btn[data-difficulty="maddening"]:hover {
+    border-color: #8a4a4a;
+    box-shadow: 0 4px 12px rgba(192, 112, 112, 0.4);
+  }
+
+  .difficulty-btn.active {
+    transform: translateY(-1px);
+    box-shadow: 0 0 0 3px rgba(102, 179, 255, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="tutorial"].active {
+    background: #3a5a3a;
+    border-color: #6a9a6a;
+    color: #b0e0b0;
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"].active {
+    background: #3a3a5a;
+    border-color: #6a6a9a;
+    color: #b0b0e0;
+  }
+
+  .difficulty-btn[data-difficulty="normal"].active {
+    background: #3a5a7a;
+    border-color: #66b3ff;
+    color: #ffffff;
+  }
+
+  .difficulty-btn[data-difficulty="hard"].active {
+    background: #5a3a3a;
+    border-color: #9a6a6a;
+    color: #e0b0b0;
+  }
+
+  .difficulty-btn[data-difficulty="maddening"].active {
+    background: #5a2a2a;
+    border-color: #9a4a4a;
+    color: #e09090;
+    box-shadow: 0 0 0 3px rgba(192, 112, 112, 0.4);
+  }
+
+  .difficulty-name {
+    display: block;
+  }
+
+  /* Tooltip styles */
+  .difficulty-btn::after {
+    content: attr(title);
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #1a1a1a;
+    color: #e0e0e0;
+    padding: 0.5rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+    margin-bottom: 0.25rem;
+    border: 1px solid #333;
+    z-index: 1000;
+  }
+
+  .difficulty-btn:hover::after {
+    opacity: 1;
+  }
+
+  /* Mobile responsiveness */
+  @media (max-width: 640px) {
+    .difficulty-buttons {
+      gap: 0.5rem;
+    }
+
+    .difficulty-btn {
+      padding: 0.5rem 0.75rem;
+      font-size: 0.75rem;
+    }
+
+    .difficulty-btn::after {
+      display: none; /* Hide tooltips on mobile */
+    }
+  }
+
+  /* Reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .difficulty-btn {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/FullBiographyContent.astro
+++ b/src/components/FullBiographyContent.astro
@@ -1,0 +1,54 @@
+---
+import { fullBiographyContent, type FullBiographyData } from '../data/full-biography-difficulty';
+
+interface Props {
+  currentLevel?: string;
+}
+
+const { currentLevel = 'normal' } = Astro.props;
+---
+
+{Object.entries(fullBiographyContent).map(([level, ContentComponent]) => {
+  const Content = ContentComponent.default || ContentComponent.Content || ContentComponent;
+  return (
+    <article 
+      class="content biography-content" 
+      data-difficulty-content={level}
+      aria-live="polite"
+    >
+      <Content />
+    </article>
+  );
+})}
+
+<style>
+  .biography-content {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.4s ease, transform 0.4s ease;
+    display: none;
+  }
+
+  .biography-content.active {
+    opacity: 1;
+    transform: translateY(0);
+    display: block;
+  }
+
+  .biography-content.fade-in {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .biography-content.fade-out {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+
+  /* Reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .biography-content {
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/FullBiographyDifficultySelector.astro
+++ b/src/components/FullBiographyDifficultySelector.astro
@@ -1,0 +1,192 @@
+---
+import { DIFFICULTY_LEVELS } from '../data/full-biography-difficulty';
+
+interface Props {
+  defaultLevel?: string;
+}
+
+const { defaultLevel = 'normal' } = Astro.props;
+---
+
+<div class="biography-difficulty-selector">
+  <div class="difficulty-buttons">
+    {DIFFICULTY_LEVELS.map((level) => (
+      <button 
+        class="difficulty-btn" 
+        data-difficulty={level.id}
+        title={level.description}
+        aria-label={`Switch to ${level.name} difficulty level - ${level.description}`}
+        aria-pressed="false"
+        role="button"
+        tabindex="0"
+      >
+        <span class="difficulty-name">{level.name}</span>
+      </button>
+    ))}
+  </div>
+</div>
+
+<style>
+  .biography-difficulty-selector {
+    display: flex;
+    justify-content: center;
+    margin: 2rem 0;
+  }
+
+  .difficulty-buttons {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    max-width: 100%;
+  }
+
+  .difficulty-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.25rem;
+    background: #2a2a2a;
+    border: 2px solid #404040;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: inherit;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  /* Progressive visual complexity for difficulty levels */
+  .difficulty-btn[data-difficulty="tutorial"] {
+    background: #2a3a2a;
+    border-color: #4a6a4a;
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"] {
+    background: #2a2a3a;
+    border-color: #4a4a6a;
+  }
+
+  .difficulty-btn[data-difficulty="normal"] {
+    background: #2a2a2a;
+    border-color: #6a6a6a;
+  }
+
+  .difficulty-btn[data-difficulty="hard"] {
+    background: #3a2a2a;
+    border-color: #6a4a4a;
+  }
+
+  .difficulty-btn[data-difficulty="maddening"] {
+    background: #3a1a1a;
+    border-color: #6a2a2a;
+    box-shadow: 0 0 8px rgba(192, 112, 112, 0.2);
+  }
+
+  .difficulty-btn:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  }
+
+  .difficulty-btn[data-difficulty="tutorial"]:hover {
+    border-color: #6a8a6a;
+    box-shadow: 0 6px 20px rgba(144, 192, 144, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"]:hover {
+    border-color: #6a6a8a;
+    box-shadow: 0 6px 20px rgba(144, 144, 192, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="normal"]:hover {
+    border-color: #8a8a8a;
+    box-shadow: 0 6px 20px rgba(192, 192, 192, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="hard"]:hover {
+    border-color: #8a6a6a;
+    box-shadow: 0 6px 20px rgba(192, 144, 144, 0.3);
+  }
+
+  .difficulty-btn[data-difficulty="maddening"]:hover {
+    border-color: #8a4a4a;
+    box-shadow: 0 6px 20px rgba(192, 112, 112, 0.5);
+  }
+
+  .difficulty-btn.active {
+    transform: translateY(-2px);
+    box-shadow: 0 0 0 3px rgba(102, 179, 255, 0.5);
+  }
+
+  .difficulty-btn[data-difficulty="tutorial"].active {
+    background: #3a5a3a;
+    border-color: #6a9a6a;
+  }
+
+  .difficulty-btn[data-difficulty="story-mode"].active {
+    background: #3a3a5a;
+    border-color: #6a6a9a;
+  }
+
+  .difficulty-btn[data-difficulty="normal"].active {
+    background: #3a5a7a;
+    border-color: #66b3ff;
+  }
+
+  .difficulty-btn[data-difficulty="hard"].active {
+    background: #5a3a3a;
+    border-color: #9a6a6a;
+  }
+
+  .difficulty-btn[data-difficulty="maddening"].active {
+    background: #5a2a2a;
+    border-color: #9a4a4a;
+    box-shadow: 0 0 0 3px rgba(192, 112, 112, 0.6);
+  }
+
+  .difficulty-name {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #e0e0e0;
+  }
+
+  .difficulty-btn.active .difficulty-name {
+    color: #ffffff;
+  }
+
+  /* Mobile responsiveness */
+  @media (max-width: 768px) {
+    .biography-difficulty-selector {
+      margin: 1rem 0;
+    }
+
+    .difficulty-buttons {
+      gap: 0.5rem;
+    }
+
+    .difficulty-btn {
+      padding: 0.5rem 0.75rem;
+    }
+
+    .difficulty-name {
+      font-size: 0.75rem;
+    }
+  }
+
+  @media (max-width: 480px) {
+    .difficulty-btn {
+      padding: 0.5rem 0.5rem;
+    }
+
+    .difficulty-name {
+      font-size: 0.7rem;
+    }
+  }
+
+  /* Reduced motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .difficulty-btn {
+      transition: none;
+    }
+  }
+</style>

--- a/src/data/bio-flavors.ts
+++ b/src/data/bio-flavors.ts
@@ -1,0 +1,65 @@
+export interface BioFlavor {
+  id: string;
+  name: string;
+  description: string;
+  content: string;
+  emoji: string;
+}
+
+export const bioFlavors: BioFlavor[] = [
+  {
+    id: 'professional',
+    name: 'Professional',
+    description: 'LinkedIn-ready version',
+    emoji: '💼',
+    content: `Hello! I'm <strong>Emily Cogsdill</strong>, a software engineer with expertise in full-stack development, 
+    system architecture, and cloud technologies. I'm passionate about building scalable solutions and contributing to 
+    open-source projects. Connect with me on <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a> 
+    or explore my work on <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a>.`
+  },
+  {
+    id: 'casual',
+    name: 'Casual',
+    description: 'Friendly and approachable',
+    emoji: '😊',
+    content: `Hello! I'm <strong>Emily</strong>, an engineering type just trying to have a good time. GOD FORBID.
+    Check out my <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> or
+    <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>, I guess.`
+  },
+  {
+    id: 'sarcastic',
+    name: 'Sarcastic',
+    description: 'Witty and tongue-in-cheek',
+    emoji: '😏',
+    content: `Oh, hi there! I'm <strong>Emily</strong>, allegedly a "software engineer" who spends way too much time 
+    arguing with computers and somehow gets paid for it. When I'm not debugging other people's "features," you can find 
+    my questionable code on <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> or my overly 
+    professional facade on <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>. 
+    Results may vary.`
+  },
+  {
+    id: 'technical',
+    name: 'Technical',
+    description: 'Engineering-focused details',
+    emoji: '🔧',
+    content: `Hi! I'm <strong>Emily</strong>, a software engineer specializing in TypeScript, React, Node.js, and cloud 
+    infrastructure. I work with modern web frameworks, API design, database optimization, and CI/CD pipelines. 
+    Currently exploring Astro, Cloudflare Workers, and edge computing. View my technical projects on 
+    <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> or professional experience on 
+    <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>.`
+  },
+  {
+    id: 'mysterious',
+    name: 'Mysterious',
+    description: 'Enigmatic and intriguing',
+    emoji: '🌙',
+    content: `They call me <strong>Emily</strong>... among other things. I emerge from the digital shadows to craft 
+    code that dances between logic and chaos. Some say I speak fluent TypeScript in my sleep. Others whisper that 
+    I can debug production issues with nothing but semicolons and determination. The truth lies somewhere in my 
+    <a href="https://www.github.com/emily-flambe" target="_blank">repositories</a>, if you dare to seek it. 
+    Professional inquiries may find me lurking on 
+    <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>... occasionally.`
+  }
+];
+
+export const defaultFlavorId = 'casual';

--- a/src/data/biography-difficulty.ts
+++ b/src/data/biography-difficulty.ts
@@ -1,0 +1,70 @@
+export interface DifficultyLevel {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface BiographyData {
+  tutorial: string;
+  'story-mode': string;
+  normal: string;
+  hard: string;
+  maddening: string;
+}
+
+export const DIFFICULTY_LEVELS: DifficultyLevel[] = [
+  {
+    id: 'tutorial',
+    name: 'Tutorial',
+    description: 'Basic facts and essential information'
+  },
+  {
+    id: 'story-mode',
+    name: 'Story Mode',
+    description: 'Key life events and background'
+  },
+  {
+    id: 'normal',
+    name: 'Normal',
+    description: 'Balanced overview with personality'
+  },
+  {
+    id: 'hard',
+    name: 'Hard',
+    description: 'Detailed stories and insights'
+  },
+  {
+    id: 'maddening',
+    name: 'Maddening',
+    description: 'Complete unfiltered biography'
+  }
+];
+
+export const biographyContent: BiographyData = {
+  tutorial: `Hello! I'm <strong>Emily</strong>, a software engineer who builds web applications.`,
+  
+  'story-mode': `Hello! I'm <strong>Emily</strong>, an engineering type who discovered coding and never looked back. 
+  I build things on the web and try to make them not terrible.`,
+  
+  normal: `Hello! I'm <strong>Emily</strong>, an engineering type just trying to have a good time. GOD FORBID.
+  Check out my <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> or
+  <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a>, I guess.`,
+  
+  hard: `Hello! I'm <strong>Emily</strong>, an engineering type just trying to have a good time. GOD FORBID.
+  I spend my days wrestling with TypeScript, building web applications, and pretending I understand how databases work.
+  When I'm not debugging someone else's "temporary" solution from 2019, you can find me on
+  <a href="https://www.github.com/emily-flambe" target="_blank">GitHub</a> committing crimes against clean code, or on
+  <a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">LinkedIn</a> maintaining the professional facade.`,
+  
+  maddening: `Hello! I'm <strong>Emily</strong>, an engineering type just trying to have a good time. GOD FORBID.
+  I spend my days wrestling with TypeScript, building web applications, and pretending I understand how databases work.
+  When I'm not debugging someone else's "temporary" solution from 2019, you can find me questioning my life choices
+  while staring at a screen full of red squiggly lines. I have strong opinions about semicolons, an unhealthy
+  relationship with CSS, and I once spent three hours debugging a problem that was solved by turning it off and on again.
+  My GitHub (<a href="https://www.github.com/emily-flambe" target="_blank">emily-flambe</a>) is a monument to my
+  hubris, and my LinkedIn (<a href="https://www.linkedin.com/in/emilycogsdill" target="_blank">profile</a>) is a
+  carefully curated lie about how together I have it all. I believe in the Oxford comma, tabs over spaces (fight me),
+  and that there are only two hard problems in computer science: cache invalidation, naming things, and off-by-one errors.`
+};
+
+export const DEFAULT_DIFFICULTY = 'normal';

--- a/src/data/biography-levels/hard.md
+++ b/src/data/biography-levels/hard.md
@@ -1,6 +1,6 @@
 Welcome to my bio on Hard difficulty! Fallen units in Hard mode are lost forever. In fact, many things are lost forever. Innocence, youth, the sweet pain of a heart learning to fall in love.
 
-Yet many things persist forever, too - an inescapable feeling of inadequacy, a failure to live up to your own standards, the creeping sensation of profound and cosmic loneliness every time you remember - or perhaps realize again for the first time - that nobody will ever really understand <em>you</em>?
+Yet many things persist forever, too - an inescapable feeling of inadequacy, a failure to live up to your own expectations, the creeping sensation of profound and cosmic loneliness every time you remember - or perhaps realize again for the first time - that nobody will ever really understand <em>you</em>?
 
 Then again, can you blame them? After all, do you understand yourself?
 
@@ -10,9 +10,11 @@ Every day you tread a narrow path cut into the wall of a deep crater. It only go
 
 Hmm, what else...
 
-I have an extreme amount of patience for the misbehaviors of animals and, very unfortunately, men I am attracted to (but I repeat myself). I have little patience for children (I know it's not their fault, except sometimes it is!) and troglodytes on the internet. You would think nobody on HackerNews ever pushed a bug to production - sheesh!
+I have an extreme amount of patience for the misbehaviors of animals and, very unfortunately, men I am attracted to (but I repeat myself). I have zero patience for children, "enlightened centrists," and troglodytes on the internet (but I repeat myself). You would think nobody on HackerNews ever pushed a bug to production - sheesh!
 
-I am easy to befriend - at least, I think? Yet my background and interests make me profoundly unrelatable. I'm vegan and absolutely do NOT want to hear about how you "can't give up cheese." Why is it always cheese? At least the internet grew bored of obsessing over bacon. GOD, that was tedious.
+I am easy to befriend - at least, I think? Yet my background and interests make me profoundly unrelatable.
+
+I'm vegan and absolutely do NOT want to hear about how you "can't give up cheese." Why is it always cheese? At least the internet grew bored of obsessing over bacon. GOD, that was tedious.
 
 I enjoy spending lots of time alone. Don't get your hopes up, <em>bachelors</em>.
 

--- a/src/data/biography-levels/hard.md
+++ b/src/data/biography-levels/hard.md
@@ -1,0 +1,21 @@
+Welcome to my bio on Hard difficulty! Fallen units in Hard mode are lost forever. In fact, many things are lost forever. Innocence, youth, the sweet pain of a heart learning to fall in love.
+
+Yet many things persist forever, too - an inescapable feeling of inadequacy, a failure to live up to your own standards, the creeping sensation of profound and cosmic loneliness every time you remember - or perhaps realize again for the first time - that nobody will ever really understand <em>you</em>?
+
+Then again, can you blame them? After all, do you understand yourself?
+
+Every day you tread a narrow path cut into the wall of a deep crater. It only goes around and around. You cannot climb out. It is all you can do to look forward, walk straight, and pray to an indifferent God that you won't fall in. But one day, you will.
+
+---
+
+Hmm, what else...
+
+I have an extreme amount of patience for the misbehaviors of animals and, very unfortunately, men I am attracted to (but I repeat myself). I have little patience for children (I know it's not their fault, except sometimes it is!) and troglodytes on the internet. You would think nobody on HackerNews ever pushed a bug to production - sheesh!
+
+I am easy to befriend - at least, I think? Yet my background and interests make me profoundly unrelatable. I'm vegan and absolutely do NOT want to hear about how you "can't give up cheese." Why is it always cheese? At least the internet grew bored of obsessing over bacon. GOD, that was tedious.
+
+I enjoy spending lots of time alone. Don't get your hopes up, <em>bachelors</em>.
+
+I will <em>literally</em> escape into the mountains for at least 4 months the MOMENT the following conditions are met: 1) my cats are dead; 2) it's not an election year; 3) current month is between April and July.
+
+Thanks for reading!

--- a/src/data/biography-levels/hard.md
+++ b/src/data/biography-levels/hard.md
@@ -1,6 +1,6 @@
 Welcome to my bio on Hard difficulty! Fallen units in Hard mode are lost forever. In fact, many things are lost forever. Innocence, youth, the sweet pain of a heart learning to fall in love.
 
-Yet many things persist forever, too - an inescapable feeling of inadequacy, a failure to live up to your own expectations, the creeping sensation of profound and cosmic loneliness every time you remember - or perhaps realize again for the first time - that nobody will ever really understand <em>you</em>?
+Yet many things persist forever, too - an inescapable feeling of inadequacy, a failure to live up to your own expectations, the creeping sensation of profound and cosmic loneliness every time you remember - or perhaps realize again, as if for the first time - that nobody will ever really understand <em>you</em>?
 
 Then again, can you blame them? After all, do you understand yourself?
 
@@ -18,6 +18,6 @@ I'm vegan and absolutely do NOT want to hear about how you "can't give up cheese
 
 I enjoy spending lots of time alone. Don't get your hopes up, <em>bachelors</em>.
 
-I will <em>literally</em> escape into the mountains for at least 4 months the MOMENT the following conditions are met: 1) my cats are dead; 2) it's not an election year; 3) current month is between April and July.
+I will <em>literally</em> escape into the mountains for at least 4 months the MOMENT the following conditions are met: 1) my cats are dead; 2) it's an odd-numbered year; 3) current month is between April and July.
 
 Thanks for reading!

--- a/src/data/biography-levels/maddening.md
+++ b/src/data/biography-levels/maddening.md
@@ -1,0 +1,41 @@
+I was born in Ann Arbor, Michigan on a Wednesday in February many years ago in the midst of a raging winter storm. I've been told I was giggling shortly after I was born. I've also been told that I telepathically communicated my arrival as my Mom was going into labor. Epistemic status: questionable.
+
+---
+
+My Dad, a devout Mormon (and crypto-fascist conservative Republican), once declared without a shred of irony that I had clairvoyant powers. I was six years old, and as Mormon as a 6-year-old can be, which is to say not very Mormon at all. There was a seagull performance involved - a story for another time.
+
+Isn't it odd that some children readily shape themselves into the molds created by their parents, while others spend their entire lives breaking free from those same molds, and still others remain perpetually torn between their true identity and the one their parents (and others) envision for them? How much collective trauma has humanity endured simply because people insist on trying to bend their offspring to their will?
+
+I stopped attending Church as soon as Dad gave up on forcing me to go when I was 9 years old. For my part, I will never force a child to fit any mold of my own creation - not least of all because I intentionally had my fallopian tubes removed in 2022. I called to schedule the appointment almost immediately before the Supreme Court overturned Roe v. Wade. The timing was prescient. Dare I say… clairvoyant?
+
+---
+
+Motherhood has never interested me. Whatever nascent maternal impulses show up in some children utterly failed to materialize in my youth (nor indeed at any point thereafter). I had absolutely no clue what I was supposed to do with baby dolls. Cabbage patch kids in particular weirded me out, with those strange little elbows, and they smelled odd.
+
+Much to my chagrin, my PhD adviser forcefully nudged me in the direction of studying children for my graduate research. This, among other factors, made the experience of earning my PhD highly unpleasant, to say the least. I made the speedrun leaderboards at Harvard by finishing - no glitches, no hacks - after only three and a half years. I did not achieve this feat with a superhuman intelligence; I was propelled in my feverish pursuits by a burning, nauseating desire to flee academia and to quit spending my precious life energy suppressing dry heaves when children would smear thick wads of snot onto my laptop. And being clairvoyant definitely didn't hurt.
+
+---
+
+Graduate school was my own Hunger Games. Each year, in those days (maybe still?), there were only 10-15 PhD students across the entire department, and we all knew that we were in the running for the same limited set of tenure-track faculty positions at top research institutions. A subset of my cohort designated themselves the "Doctors of Velocity," a moniker that is so aggressively insufferable that I remain traumatized to this day. Then again, they are all tenured faculty at prestigious universities, and I'm vibecoding alone in the mountains with two cats. I guess we all got what we wanted.
+
+Maybe I envy their prestige. But I am prestigious in my own way! I know this because my mother tells me so.
+
+Back in 2017, a friend of mine and I were both staying at my Mom's house in Colorado. At that time, this friend was a fancy Research Engineer at Google with a fancy PhD in Computer Science from Berkeley. My Mom, in her bumbling and good-natured way, took his existence as a mild affront to my superiority, and would repeatedly remind him that I was an analyst at Under Armour(!).
+
+That friend later quit Google to study meditation and do independent research, and I'm vibecoding in the mountains with two cats. Have we both gotten what we wanted?
+
+---
+
+Much to her credit, my Mom - who was only briefly Mormon enough to marry my Dad - always told me I could be whatever I wanted to be and do whatever I wanted to do. And she meant it. In high school, I semi-quasi-seriously contemplated applying to conservatories to study clarinet performance. Of all my innate talents, music is probably the one where I get the most mileage per unit of effort. Mom supported this plan, and it was I who eventually decided against it.
+
+What she always did impress upon me, however, was that I needed to pursue a terminal degree in whatever profession I chose, or else some man with the same degree or higher would become my boss and I would have to answer to him. No doubt this contributed to my decision to pursue a PhD immediately after finishing my undergraduate studies (in Psychology and Music, as it happens) at Carleton College.
+
+Mom herself was a notable-ish Professor of Accounting, with an MBA and a PhD both from Michigan and a career that included a stint at the Tuck School of Business at Dartmouth, which is how I came to spend most of my childhood in Hanover, NH. Dad did not have a career. They divorced bitterly in 1998 and later reconvened as platonic life partners. In their old age, Dad reads about Michigan Football and Mom does his taxes. Go figure that one out.
+
+---
+
+Despite having a fancy PhD, in the "working world" I have answered more often than not to men without PhDs of any sort(!)). I have also reported to a handful of women, who - much more so than my male bosses (by and large) - taught me how to assert myself, ask for what I want, hold leadership accountable, build my personal brand, and pursue my own ideas. Makes you think, huh?
+
+To be clear, I have been blessed with great bosses across the board. In fact, I have been profoundly fortunate in a lot of ways, starting from my snowy yet uncomplicated birth. I try to make productive use of that fortune to enjoy my life as much as possible AND, hopefully, be useful in the service of things that are net-positive for humanity. I suspect people often have children at least in part because they want to know that they had some unambiguously positive impact on the world. I share that impulse alongside a strong aversion to birthing and parenting.
+
+Where does it all converge? I'd love to tell you, but I'm not that clairvoyant...

--- a/src/data/biography-levels/normal.md
+++ b/src/data/biography-levels/normal.md
@@ -1,0 +1,1 @@
+On further reflection, I don't think I am capable of writing a normal bio.

--- a/src/data/biography-levels/story-mode.md
+++ b/src/data/biography-levels/story-mode.md
@@ -1,0 +1,2 @@
+Hi! I'm Emily. What is this, a DATING PROFILE? ha ha ha
+

--- a/src/data/biography-levels/tutorial.md
+++ b/src/data/biography-levels/tutorial.md
@@ -1,0 +1,1 @@
+Hi! I'm Emily. I'm a single woman in my thirties living with two cats in Colorado, sometimes in my mom's basement. I make weird things on the internet. Get in line, bachelors!!

--- a/src/data/full-biography-difficulty.ts
+++ b/src/data/full-biography-difficulty.ts
@@ -1,0 +1,58 @@
+export interface DifficultyLevel {
+  id: string;
+  name: string;
+  description: string;
+}
+
+export interface FullBiographyData {
+  tutorial: any;
+  'story-mode': any;
+  normal: any;
+  hard: any;
+  maddening: any;
+}
+
+export const DIFFICULTY_LEVELS: DifficultyLevel[] = [
+  {
+    id: 'tutorial',
+    name: 'Tutorial',
+    description: 'Basic facts and essential information'
+  },
+  {
+    id: 'story-mode',
+    name: 'Story Mode',
+    description: 'Key life events and background'
+  },
+  {
+    id: 'normal',
+    name: 'Normal',
+    description: 'Balanced overview with personality'
+  },
+  {
+    id: 'hard',
+    name: 'Hard',
+    description: 'Detailed stories and insights'
+  },
+  {
+    id: 'maddening',
+    name: 'Maddening',
+    description: 'Complete unfiltered biography'
+  }
+];
+
+// Import markdown files as components
+import tutorialContent from './biography-levels/tutorial.md';
+import storyModeContent from './biography-levels/story-mode.md';
+import normalContent from './biography-levels/normal.md';
+import hardContent from './biography-levels/hard.md';
+import maddeningContent from './biography-levels/maddening.md';
+
+export const fullBiographyContent: FullBiographyData = {
+  tutorial: tutorialContent,
+  'story-mode': storyModeContent,
+  normal: normalContent,
+  hard: hardContent,
+  maddening: maddeningContent
+};
+
+export const DEFAULT_DIFFICULTY = 'tutorial';

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -1,42 +1,39 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Bio from '../components/Bio.astro';
-import getPostData from '../utils/getPostData';
+import FullBiographyDifficultySelector from '../components/FullBiographyDifficultySelector.astro';
+import FullBiographyContent from '../components/FullBiographyContent.astro';
+import { DEFAULT_DIFFICULTY } from '../data/full-biography-difficulty';
 
 const title = 'Bio';
 const description = 'About Emily - kinda';
 const permalink = `${Astro.site.href}bio`;
 
-// Load the specific bio blog post
-const postModules = import.meta.glob('../data/blog-posts/published/*.md', { eager: true });
-const posts = Object.entries(postModules).map(([path, module]) => ({
-  ...module,
-  file: path
-}));
+// Create fake frontmatter for the difficulty selector version
+const frontmatter = {
+  title: 'A Bio, kind of',
+  publishDate: '20 Jul 2025'
+};
 
-const bioPost = posts.find(p => {
-  const postSlug = p.file.split('/').pop().split('.').shift();
-  return postSlug === '20250720-bio';
-});
-
-if (!bioPost) {
-  throw new Error('Bio post not found');
-}
-
-const { Content, frontmatter } = bioPost;
-const { readingTime } = getPostData(bioPost);
+// Estimate reading times for different difficulty levels
+const estimatedReadingTimes = {
+  tutorial: '< 1 min read',
+  'story-mode': '1 min read',
+  normal: '3 min read',
+  hard: '5 min read',
+  maddening: '8 min read'
+};
 ---
 
 <BaseLayout title={title} description={description} permalink={permalink} current="bio">
   <header>
-    <p>{frontmatter.publishDate} ~ {readingTime}</p>
+    <p id="reading-time-display">{frontmatter.publishDate} ~ 3 min read</p>
     <h1>{frontmatter.title}</h1>
     <hr />
   </header>
   <div class="container">
-    <article class="content">
-      <Content />
-    </article>
+    <FullBiographyDifficultySelector defaultLevel={DEFAULT_DIFFICULTY} />
+    <FullBiographyContent currentLevel={DEFAULT_DIFFICULTY} />
     <hr />
     <div class="back-to-blog">
       <a href="/blog">→ View blog posts</a>
@@ -46,6 +43,220 @@ const { readingTime } = getPostData(bioPost);
     <Bio />
   </div>
 </BaseLayout>
+
+<script define:vars={{ estimatedReadingTimes }}>
+  class FullBiographyDifficultyManager {
+    private currentDifficulty: string;
+    private buttons: NodeListOf<HTMLButtonElement>;
+    private textElements: NodeListOf<HTMLDivElement>;
+    private readingTimeDisplay: HTMLElement | null;
+    private readonly STORAGE_KEY = 'full-biography-difficulty';
+    private readonly readingTimes: Record<string, string>;
+
+    constructor() {
+      this.currentDifficulty = 'normal'; // Default difficulty
+      this.buttons = document.querySelectorAll('.difficulty-btn');
+      this.textElements = document.querySelectorAll('[data-difficulty-content]');
+      this.readingTimeDisplay = document.getElementById('reading-time-display');
+      this.readingTimes = estimatedReadingTimes;
+      
+      this.init();
+    }
+
+    private init() {
+      // Load saved preference from localStorage first
+      const savedDifficulty = this.loadSavedDifficulty();
+      if (savedDifficulty && this.isValidDifficulty(savedDifficulty)) {
+        this.currentDifficulty = savedDifficulty;
+      }
+      
+      // Set initial active states
+      this.updateDisplay();
+      
+      // Add click handlers to buttons
+      this.buttons.forEach(button => {
+        button.addEventListener('click', (e) => {
+          const target = e.currentTarget as HTMLButtonElement;
+          const difficultyId = target.dataset.difficulty;
+          if (difficultyId && this.isValidDifficulty(difficultyId)) {
+            this.setDifficulty(difficultyId);
+          }
+        });
+
+        // Add keyboard support
+        button.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            button.click();
+          }
+        });
+      });
+
+      // Add keyboard navigation between buttons
+      this.addKeyboardNavigation();
+    }
+
+    private addKeyboardNavigation() {
+      this.buttons.forEach((button, index) => {
+        button.addEventListener('keydown', (e) => {
+          let targetIndex = index;
+          
+          switch(e.key) {
+            case 'ArrowLeft':
+            case 'ArrowUp':
+              e.preventDefault();
+              targetIndex = index > 0 ? index - 1 : this.buttons.length - 1;
+              break;
+            case 'ArrowRight':
+            case 'ArrowDown':
+              e.preventDefault();
+              targetIndex = index < this.buttons.length - 1 ? index + 1 : 0;
+              break;
+            case 'Home':
+              e.preventDefault();
+              targetIndex = 0;
+              break;
+            case 'End':
+              e.preventDefault();
+              targetIndex = this.buttons.length - 1;
+              break;
+          }
+          
+          if (targetIndex !== index) {
+            this.buttons[targetIndex].focus();
+          }
+        });
+      });
+    }
+
+    private isValidDifficulty(difficulty: string): boolean {
+      return ['tutorial', 'story-mode', 'normal', 'hard', 'maddening'].includes(difficulty);
+    }
+
+    private loadSavedDifficulty(): string | null {
+      try {
+        return localStorage.getItem(this.STORAGE_KEY);
+      } catch (error) {
+        console.warn('Failed to load difficulty preference from localStorage:', error);
+        return null;
+      }
+    }
+
+    private saveDifficulty(difficulty: string): void {
+      try {
+        localStorage.setItem(this.STORAGE_KEY, difficulty);
+      } catch (error) {
+        console.warn('Failed to save difficulty preference to localStorage:', error);
+      }
+    }
+
+    private setDifficulty(difficultyId: string) {
+      this.currentDifficulty = difficultyId;
+      this.updateDisplay();
+      this.saveDifficulty(difficultyId);
+      
+      // Trigger custom event for potential analytics/tracking
+      window.dispatchEvent(new CustomEvent('full-biography-difficulty-changed', {
+        detail: { difficulty: difficultyId }
+      }));
+    }
+
+    private updateDisplay() {
+      // Update button states
+      this.buttons.forEach(button => {
+        const isActive = button.dataset.difficulty === this.currentDifficulty;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-pressed', isActive.toString());
+      });
+
+      // Update text visibility with smooth transitions
+      this.textElements.forEach(element => {
+        const isVisible = element.dataset.difficultyContent === this.currentDifficulty;
+        
+        if (isVisible) {
+          // Show the active content
+          element.style.display = 'block';
+          element.classList.add('active');
+          element.classList.add('fade-in');
+          element.classList.remove('fade-out');
+        } else {
+          // Hide inactive content
+          element.classList.remove('active', 'fade-in');
+          element.classList.add('fade-out');
+          
+          // Hide after transition
+          setTimeout(() => {
+            if (!element.classList.contains('active')) {
+              element.style.display = 'none';
+            }
+          }, 400);
+        }
+      });
+
+      // Update reading time display
+      if (this.readingTimeDisplay && this.readingTimes[this.currentDifficulty]) {
+        const currentText = this.readingTimeDisplay.textContent || '';
+        const newText = currentText.replace(/\d+\s*min read|<\s*\d+\s*min read/, this.readingTimes[this.currentDifficulty]);
+        this.readingTimeDisplay.textContent = newText;
+      }
+    }
+
+    // Fallback method for when content is missing
+    private getFallbackContent(): string {
+      const fallbackOrder = ['normal', 'story-mode', 'tutorial'];
+      
+      for (const difficulty of fallbackOrder) {
+        const element = document.querySelector(`[data-difficulty-content="${difficulty}"]`);
+        if (element) {
+          return difficulty;
+        }
+      }
+      
+      return 'normal'; // Ultimate fallback
+    }
+  }
+
+  // Initialize when DOM is ready
+  function initializeFullBiographyDifficulty() {
+    if (document.querySelector('.difficulty-btn')) {
+      new FullBiographyDifficultyManager();
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initializeFullBiographyDifficulty);
+  } else {
+    initializeFullBiographyDifficulty();
+  }
+
+  // Graceful degradation: if JavaScript fails, show normal difficulty
+  window.addEventListener('error', () => {
+    const normalContent = document.querySelector('[data-difficulty-content="normal"]') as HTMLElement;
+    if (normalContent) {
+      normalContent.style.display = 'block';
+      normalContent.style.position = 'relative';
+      normalContent.classList.add('active');
+    }
+  });
+</script>
+
+<!-- Fallback for when JavaScript is disabled -->
+<noscript>
+  <style>
+    [data-difficulty-content]:not([data-difficulty-content="normal"]) {
+      display: none !important;
+    }
+    [data-difficulty-content="normal"] {
+      display: block !important;
+      position: relative !important;
+      opacity: 1 !important;
+      transform: none !important;
+    }
+    .biography-difficulty-selector {
+      display: none !important;
+    }
+  </style>
+</noscript>
 
 <style>
   header {

--- a/src/pages/bio.astro
+++ b/src/pages/bio.astro
@@ -12,7 +12,7 @@ const permalink = `${Astro.site.href}bio`;
 // Create fake frontmatter for the difficulty selector version
 const frontmatter = {
   title: 'A Bio, kind of',
-  publishDate: '20 Jul 2025'
+  publishDate: '20 Aug 2025'
 };
 
 // Estimate reading times for different difficulty levels


### PR DESCRIPTION
## Summary
Implements an interactive difficulty selector for the biography page with 5 levels:

- **Tutorial**: Basic intro for quick readers
- **Story Mode**: Slightly humorous take 
- **Normal**: Meta-commentary on bio writing
- **Hard**: Existential and personal content with humor
- **Maddening**: Full detailed biography (original content)

## Features
- Interactive button-based difficulty selector
- Smooth transitions between content levels
- localStorage persistence for user preferences
- Accessibility support (keyboard navigation, ARIA labels)
- Graceful degradation when JavaScript is disabled
- Responsive design for all device sizes

## Technical Implementation
- Fixed markdown rendering using Astro's native component imports
- Created modular components for difficulty selection and content display
- Default difficulty set to Tutorial as requested
- Updated bio publish date to 20 Aug 2025

## Test Plan
- [x] All 5 difficulty levels display correct content
- [x] Difficulty selection persists across page reloads
- [x] Smooth transitions work properly
- [x] Responsive design on mobile/desktop
- [x] Keyboard navigation functions correctly
- [x] Graceful fallback with JavaScript disabled

🤖 Generated with [Claude Code](https://claude.ai/code)