### PR TITLE
Fix email notification links with undefined domain

### DIFF
--- a/src/lib/email/content-processor.ts
+++ b/src/lib/email/content-processor.ts
@@ -302,7 +302,7 @@ export class ContentProcessor {
       
       // Try to fetch content from the deployed site's content API
       try {
-        const contentUrl = `${this.env.SITE_URL}/api/content/${slug}`;
+        const contentUrl = `https://www.emilycogsdill.com/api/content/${slug}`;
         const response = await fetch(contentUrl);
         
         if (response.ok) {

--- a/src/lib/email/gmail-auth-enhanced.ts
+++ b/src/lib/email/gmail-auth-enhanced.ts
@@ -168,7 +168,7 @@ export class GmailAuthEnhanced {
       // Create RFC 2822 compliant email
       const emailContent = [
         `To: ${to}`,
-        `From: ${this.env.SITE_NAME} <${this.env.GMAIL_SENDER_EMAIL}>`,
+        `From: Emily Cogsdill <${this.env.GMAIL_SENDER_EMAIL}>`,
         `Subject: ${subject}`,
         `MIME-Version: 1.0`,
         `Content-Type: multipart/alternative; boundary="boundary123"`,

--- a/src/lib/email/gmail-auth.ts
+++ b/src/lib/email/gmail-auth.ts
@@ -114,7 +114,7 @@ export class GmailAuth {
     console.log('[Gmail Send] Recipient:', to);
     console.log('[Gmail Send] Subject:', subject);
     console.log('[Gmail Send] Sender email:', this.env.GMAIL_SENDER_EMAIL);
-    console.log('[Gmail Send] Site name:', this.env.SITE_NAME);
+    console.log('[Gmail Send] Site name:', 'Emily Cogsdill');
     console.log('[Gmail Send] HTML content length:', htmlContent?.length || 0);
     console.log('[Gmail Send] Text content length:', textContent?.length || 0);
     
@@ -124,7 +124,7 @@ export class GmailAuth {
     // Create RFC 2822 compliant email
     const emailContent = [
       `To: ${to}`,
-      `From: ${this.env.SITE_NAME} <${this.env.GMAIL_SENDER_EMAIL}>`,
+      `From: Emily Cogsdill <${this.env.GMAIL_SENDER_EMAIL}>`,
       `Subject: ${subject}`,
       `MIME-Version: 1.0`,
       `Content-Type: multipart/alternative; boundary="boundary123"`,

--- a/src/lib/email/notification-service-enhanced.ts
+++ b/src/lib/email/notification-service-enhanced.ts
@@ -213,7 +213,7 @@ export class EmailNotificationServiceEnhanced {
             contentType,
             contentId: content.slug,
             contentTitle: content.title || 'New Content',
-            contentUrl: `${this.env.SITE_URL}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+            contentUrl: `https://www.emilycogsdill.com/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
             contentExcerpt: contentType === 'blog' 
               ? (content as BlogPost).description 
               : content.content.substring(0, 200),
@@ -226,7 +226,7 @@ export class EmailNotificationServiceEnhanced {
             contentType,
             contentId: content.slug,
             contentTitle: content.title || 'New Content',
-            contentUrl: `${this.env.SITE_URL}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+            contentUrl: `https://www.emilycogsdill.com/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
             contentExcerpt: contentType === 'blog' 
               ? (content as BlogPost).description 
               : content.content.substring(0, 200),

--- a/src/lib/email/notification-service.ts
+++ b/src/lib/email/notification-service.ts
@@ -109,7 +109,7 @@ export class EmailNotificationService {
         contentType,
         contentId: content.slug,
         contentTitle: content.title || 'New Content',
-        contentUrl: `${this.env.SITE_URL}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+        contentUrl: `https://www.emilycogsdill.com/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
         contentExcerpt: contentType === 'blog' 
           ? (content as BlogPost).description 
           : content.content.substring(0, 200),
@@ -122,7 +122,7 @@ export class EmailNotificationService {
         contentType,
         contentId: content.slug,
         contentTitle: content.title || 'New Content',
-        contentUrl: `${this.env.SITE_URL}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+        contentUrl: `https://www.emilycogsdill.com/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
         contentExcerpt: contentType === 'blog' 
           ? (content as BlogPost).description 
           : content.content.substring(0, 200),

--- a/src/lib/email/resend-service.ts
+++ b/src/lib/email/resend-service.ts
@@ -47,7 +47,7 @@ export class ResendEmailService {
           text: params.text,
           headers: {
             ...params.headers,
-            'List-Unsubscribe': `<${this.env.SITE_URL}/unsubscribe>`,
+            'List-Unsubscribe': '<https://www.emilycogsdill.com/unsubscribe>',
             'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
             'Precedence': 'bulk',
             'X-Entity-Ref-ID': `${Date.now()}-${params.to}`,

--- a/src/lib/email/simple-notification-service.ts
+++ b/src/lib/email/simple-notification-service.ts
@@ -72,7 +72,7 @@ export class SimpleEmailNotificationService {
         contentType,
         contentId: content.slug,
         contentTitle: content.title,
-        contentUrl: `${this.env.SITE_URL || 'https://www.emilycogsdill.com'}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+        contentUrl: `https://www.emilycogsdill.com/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
         contentExcerpt: content.description,
         notificationType: 'new_content'
       });
@@ -154,8 +154,8 @@ export class SimpleEmailNotificationService {
         unsubscribe_url: unsubscribeUrl,
         publish_date: content.publishDate.toLocaleDateString(),
         tags: content.tags || [],
-        site_name: this.env.SITE_NAME || 'Emily Cogsdill',
-        site_url: this.env.SITE_URL || 'https://www.emilycogsdill.com',
+        site_name: 'Emily Cogsdill',
+        site_url: 'https://www.emilycogsdill.com',
         user_name: user.username || 'Subscriber',
         content: notification.contentType === 'thought' ? (content as Thought).content : undefined
       };

--- a/src/lib/email/simple-notification-service.ts
+++ b/src/lib/email/simple-notification-service.ts
@@ -72,7 +72,7 @@ export class SimpleEmailNotificationService {
         contentType,
         contentId: content.slug,
         contentTitle: content.title,
-        contentUrl: `${this.env.SITE_URL || 'https://emilycogsdill.com'}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
+        contentUrl: `${this.env.SITE_URL || 'https://www.emilycogsdill.com'}/${contentType === 'blog' ? 'blog' : 'thoughts'}/${content.slug}`,
         contentExcerpt: content.description,
         notificationType: 'new_content'
       });
@@ -155,7 +155,7 @@ export class SimpleEmailNotificationService {
         publish_date: content.publishDate.toLocaleDateString(),
         tags: content.tags || [],
         site_name: this.env.SITE_NAME || 'Emily Cogsdill',
-        site_url: this.env.SITE_URL || 'https://emilycogsdill.com',
+        site_url: this.env.SITE_URL || 'https://www.emilycogsdill.com',
         user_name: user.username || 'Subscriber',
         content: notification.contentType === 'thought' ? (content as Thought).content : undefined
       };

--- a/src/lib/email/template-engine.ts
+++ b/src/lib/email/template-engine.ts
@@ -156,8 +156,8 @@ export class EmailTemplateEngine {
     post: BlogPost, 
     unsubscribeUrl: string
   ): Promise<{ subject: string; html: string; text: string }> {
-    const siteUrl = this.env.SITE_URL || 'https://www.emilycogsdill.com';
-    const siteName = this.env.SITE_NAME || 'Emily Cogsdill';
+    const siteUrl = 'https://www.emilycogsdill.com';
+    const siteName = 'Emily Cogsdill';
     
     const variables: TemplateVariables = {
       title: post.title,
@@ -179,8 +179,8 @@ export class EmailTemplateEngine {
     thought: Thought, 
     unsubscribeUrl: string
   ): Promise<{ subject: string; html: string; text: string }> {
-    const siteUrl = this.env.SITE_URL || 'https://www.emilycogsdill.com';
-    const siteName = this.env.SITE_NAME || 'Emily Cogsdill';
+    const siteUrl = 'https://www.emilycogsdill.com';
+    const siteName = 'Emily Cogsdill';
     
     const variables: TemplateVariables = {
       title: thought.title || 'New Thought',
@@ -203,11 +203,11 @@ export class EmailTemplateEngine {
   ): Promise<{ subject: string; html: string; text: string }> {
     const variables: TemplateVariables = {
       title: 'Welcome!',
-      url: this.env.SITE_URL,
+      url: 'https://www.emilycogsdill.com',
       unsubscribe_url: unsubscribeUrl,
       publish_date: new Date().toLocaleDateString(),
-      site_name: this.env.SITE_NAME,
-      site_url: this.env.SITE_URL,
+      site_name: 'Emily Cogsdill',
+      site_url: 'https://www.emilycogsdill.com',
       user_name: user.username
     };
     
@@ -219,11 +219,11 @@ export class EmailTemplateEngine {
   ): Promise<{ subject: string; html: string; text: string }> {
     const variables: TemplateVariables = {
       title: 'Unsubscribed',
-      url: this.env.SITE_URL,
+      url: 'https://www.emilycogsdill.com',
       unsubscribe_url: '', // Not needed for unsubscribe confirmation
       publish_date: new Date().toLocaleDateString(),
-      site_name: this.env.SITE_NAME,
-      site_url: this.env.SITE_URL,
+      site_name: 'Emily Cogsdill',
+      site_url: 'https://www.emilycogsdill.com',
       user_name: user.username
     };
     

--- a/src/lib/email/template-engine.ts
+++ b/src/lib/email/template-engine.ts
@@ -156,15 +156,18 @@ export class EmailTemplateEngine {
     post: BlogPost, 
     unsubscribeUrl: string
   ): Promise<{ subject: string; html: string; text: string }> {
+    const siteUrl = this.env.SITE_URL || 'https://www.emilycogsdill.com';
+    const siteName = this.env.SITE_NAME || 'Emily Cogsdill';
+    
     const variables: TemplateVariables = {
       title: post.title,
       description: post.description,
-      url: `${this.env.SITE_URL}/blog/${post.slug}`,
+      url: `${siteUrl}/blog/${post.slug}`,
       unsubscribe_url: unsubscribeUrl,
       publish_date: post.publishDate.toLocaleDateString(),
       tags: post.tags,
-      site_name: this.env.SITE_NAME,
-      site_url: this.env.SITE_URL,
+      site_name: siteName,
+      site_url: siteUrl,
       user_name: user.username
     };
     
@@ -176,15 +179,18 @@ export class EmailTemplateEngine {
     thought: Thought, 
     unsubscribeUrl: string
   ): Promise<{ subject: string; html: string; text: string }> {
+    const siteUrl = this.env.SITE_URL || 'https://www.emilycogsdill.com';
+    const siteName = this.env.SITE_NAME || 'Emily Cogsdill';
+    
     const variables: TemplateVariables = {
       title: thought.title || 'New Thought',
       content: thought.content,
-      url: `${this.env.SITE_URL}/thoughts/${thought.slug}`,
+      url: `${siteUrl}/thoughts/${thought.slug}`,
       unsubscribe_url: unsubscribeUrl,
       publish_date: thought.publishDate.toLocaleDateString(),
       tags: thought.tags,
-      site_name: this.env.SITE_NAME,
-      site_url: this.env.SITE_URL,
+      site_name: siteName,
+      site_url: siteUrl,
       user_name: user.username
     };
     

--- a/src/lib/email/unsubscribe-service.ts
+++ b/src/lib/email/unsubscribe-service.ts
@@ -32,7 +32,7 @@ export class UnsubscribeService {
       expiresAt
     });
     
-    return `${this.env.SITE_URL}/unsubscribe?token=${token}`;
+    return `https://www.emilycogsdill.com/unsubscribe?token=${token}`;
   }
   
   async processUnsubscribe(token: string, ipAddress?: string, userAgent?: string): Promise<{ success: boolean; error?: string; userId?: string }> {
@@ -151,7 +151,7 @@ export class UnsubscribeService {
   // Helper method to generate List-Unsubscribe header
   generateListUnsubscribeHeader(userId: string): string {
     const token = this.generateSecureToken();
-    const unsubscribeUrl = `${this.env.SITE_URL}/unsubscribe?token=${token}`;
+    const unsubscribeUrl = `https://www.emilycogsdill.com/unsubscribe?token=${token}`;
     
     // Store token for List-Unsubscribe (simplified implementation)
     this.createUnsubscribeToken({
@@ -161,6 +161,6 @@ export class UnsubscribeService {
       expiresAt: Math.floor(Date.now() / 1000) + (365 * 24 * 60 * 60)
     });
     
-    return `<${unsubscribeUrl}>, <mailto:unsubscribe@${this.env.SITE_URL.replace('https://', '')}?subject=unsubscribe>`;
+    return `<${unsubscribeUrl}>, <mailto:unsubscribe@www.emilycogsdill.com?subject=unsubscribe>`;
   }
 }

--- a/src/pages/api/admin/test-direct-email.ts
+++ b/src/pages/api/admin/test-direct-email.ts
@@ -42,12 +42,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const testVariables = {
       title: 'Test Blog Post: Direct Template Test',
       description: 'This is a direct test of the email template system. All {{variables}} should be replaced with actual values.',
-      url: `${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}/blog/test-post`,
-      unsubscribe_url: `${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}/unsubscribe?token=test123`,
+      url: 'https://www.emilycogsdill.com/blog/test-post',
+      unsubscribe_url: 'https://www.emilycogsdill.com/unsubscribe?token=test123',
       publish_date: new Date().toLocaleDateString(),
       tags: ['test', 'email', 'template', 'debug'],
-      site_name: locals.runtime.env.SITE_NAME || "Emily's Blog",
-      site_url: locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com',
+      site_name: 'Emily Cogsdill',
+      site_url: 'https://www.emilycogsdill.com',
       user_name: email.split('@')[0], // Use email prefix as username
       content: 'This is the full content of the test blog post. It should appear in the text version of the email.'
     }

--- a/src/pages/api/admin/test-direct-email.ts
+++ b/src/pages/api/admin/test-direct-email.ts
@@ -42,12 +42,12 @@ export const POST: APIRoute = async ({ request, locals }) => {
     const testVariables = {
       title: 'Test Blog Post: Direct Template Test',
       description: 'This is a direct test of the email template system. All {{variables}} should be replaced with actual values.',
-      url: `${locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'}/blog/test-post`,
-      unsubscribe_url: `${locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'}/unsubscribe?token=test123`,
+      url: `${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}/blog/test-post`,
+      unsubscribe_url: `${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}/unsubscribe?token=test123`,
       publish_date: new Date().toLocaleDateString(),
       tags: ['test', 'email', 'template', 'debug'],
       site_name: locals.runtime.env.SITE_NAME || "Emily's Blog",
-      site_url: locals.runtime.env.SITE_URL || 'https://emilycogsdill.com',
+      site_url: locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com',
       user_name: email.split('@')[0], // Use email prefix as username
       content: 'This is the full content of the test blog post. It should appear in the text version of the email.'
     }

--- a/src/pages/api/admin/test-email-debug.ts
+++ b/src/pages/api/admin/test-email-debug.ts
@@ -63,7 +63,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         <li>Sent to: ${to}</li>
         <li>From: ${fromEmail}</li>
         <li>Environment: ${locals.runtime.env.ENVIRONMENT || 'production'}</li>
-        <li>Worker URL: ${locals.runtime.env.SITE_URL}</li>
+        <li>Worker URL: https://www.emilycogsdill.com</li>
       </ul>
     `;
     
@@ -77,7 +77,7 @@ Debug Information:
 - Sent to: ${to}
 - From: ${fromEmail}
 - Environment: ${locals.runtime.env.ENVIRONMENT || 'production'}
-- Worker URL: ${locals.runtime.env.SITE_URL}
+- Worker URL: https://www.emilycogsdill.com
 `;
     
     console.log('[Test Email Debug] Calling Resend API...');
@@ -103,7 +103,7 @@ Debug Information:
         fromEmail,
         timestamp: new Date().toISOString(),
         environment: locals.runtime.env.ENVIRONMENT || 'production',
-        siteUrl: locals.runtime.env.SITE_URL
+        siteUrl: 'https://www.emilycogsdill.com'
       } : undefined
     };
     

--- a/src/pages/api/admin/test-simple-email.ts
+++ b/src/pages/api/admin/test-simple-email.ts
@@ -45,8 +45,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
         <p>Title: {{title}}</p>
         <p>Description: {{description}}</p>
         <p>If you see actual values below, the templates ARE being processed correctly:</p>
-        <p>Site Name: ${locals.runtime.env.SITE_NAME || 'Emily\'s Blog'}</p>
-        <p>Site URL: ${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}</p>
+        <p>Site Name: Emily Cogsdill</p>
+        <p>Site URL: https://www.emilycogsdill.com</p>
       `,
       text: `Test Email
 
@@ -57,8 +57,8 @@ Title: {{title}}
 Description: {{description}}
 
 If you see actual values below, the templates ARE being processed correctly:
-Site Name: ${locals.runtime.env.SITE_NAME || 'Emily\'s Blog'}
-Site URL: ${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}`
+Site Name: Emily Cogsdill
+Site URL: https://www.emilycogsdill.com`
     }
     
     console.log('Sending simple test email with payload:', JSON.stringify(payload, null, 2))
@@ -85,8 +85,8 @@ Site URL: ${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}`
           hasResendApiKey: !!resendApiKey,
           fromEmail,
           hasTemplateVariables: payload.html.includes('{{'),
-          siteNameValue: locals.runtime.env.SITE_NAME || 'Emily\'s Blog',
-          siteUrlValue: locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'
+          siteNameValue: 'Emily Cogsdill',
+          siteUrlValue: 'https://www.emilycogsdill.com'
         }
       }), {
         status: response.ok ? 200 : response.status,

--- a/src/pages/api/admin/test-simple-email.ts
+++ b/src/pages/api/admin/test-simple-email.ts
@@ -46,7 +46,7 @@ export const POST: APIRoute = async ({ request, locals }) => {
         <p>Description: {{description}}</p>
         <p>If you see actual values below, the templates ARE being processed correctly:</p>
         <p>Site Name: ${locals.runtime.env.SITE_NAME || 'Emily\'s Blog'}</p>
-        <p>Site URL: ${locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'}</p>
+        <p>Site URL: ${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}</p>
       `,
       text: `Test Email
 
@@ -58,7 +58,7 @@ Description: {{description}}
 
 If you see actual values below, the templates ARE being processed correctly:
 Site Name: ${locals.runtime.env.SITE_NAME || 'Emily\'s Blog'}
-Site URL: ${locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'}`
+Site URL: ${locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'}`
     }
     
     console.log('Sending simple test email with payload:', JSON.stringify(payload, null, 2))
@@ -86,7 +86,7 @@ Site URL: ${locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'}`
           fromEmail,
           hasTemplateVariables: payload.html.includes('{{'),
           siteNameValue: locals.runtime.env.SITE_NAME || 'Emily\'s Blog',
-          siteUrlValue: locals.runtime.env.SITE_URL || 'https://emilycogsdill.com'
+          siteUrlValue: locals.runtime.env.SITE_URL || 'https://www.emilycogsdill.com'
         }
       }), {
         status: response.ok ? 200 : response.status,

--- a/src/pages/api/admin/test-template-render.ts
+++ b/src/pages/api/admin/test-template-render.ts
@@ -28,8 +28,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       unsubscribe_url: 'https://example.com/unsubscribe?token=test123',
       publish_date: new Date().toLocaleDateString(),
       tags: ['test', 'template', 'debug'],
-      site_name: env.SITE_NAME || 'Test Site',
-      site_url: env.SITE_URL || 'https://example.com',
+      site_name: 'Emily Cogsdill',
+      site_url: 'https://www.emilycogsdill.com',
       user_name: 'Test User',
       content: 'This is test content for thought notifications.'
     };
@@ -75,8 +75,8 @@ export const POST: APIRoute = async ({ request, locals }) => {
       testVariables,
       debug: {
         hasTemplateEngine: !!templateEngine,
-        envSiteName: env.SITE_NAME,
-        envSiteUrl: env.SITE_URL
+        envSiteName: 'Emily Cogsdill',
+        envSiteUrl: 'https://www.emilycogsdill.com'
       }
     }, null, 2), {
       status: 200,

--- a/src/types/env.ts
+++ b/src/types/env.ts
@@ -16,9 +16,9 @@ export interface Env {
   RESEND_API_KEY: string;
   RESEND_FROM_EMAIL?: string;
   
-  // Site Configuration
-  SITE_URL: string;
-  SITE_NAME: string;
+  // Site Configuration (optional - hard-coded in email services)
+  SITE_URL?: string;
+  SITE_NAME?: string;
   
   // Content Storage (optional)
   CONTENT_KV?: KVNamespace;

--- a/wrangler.json
+++ b/wrangler.json
@@ -19,8 +19,6 @@
     }
   ],
   "vars": {
-    "SITE_URL": "https://emilycogsdill.com",
-    "SITE_NAME": "Emily's Blog",
     "ENVIRONMENT": "preview"
   }
 }


### PR DESCRIPTION
## Summary
Fixed email notification links that were showing `http://undefined/thoughts/...` instead of the correct domain.

## Problem
Email notifications were generating broken links with "undefined" as the domain, making them unclickable for users.

## Solution
Hard-coded the site URL and name throughout the email services instead of relying on environment variables, since this is a personal website with a fixed domain that won't change.

## Changes
- Replaced all instances of `env.SITE_URL` with hard-coded `https://www.emilycogsdill.com`
- Replaced all instances of `env.SITE_NAME` with hard-coded `Emily Cogsdill`
- Made SITE_URL and SITE_NAME optional in the TypeScript Env interface
- Removed these variables from wrangler.json configuration
- Updated 15 files across email services, test endpoints, and configuration

## Benefits
- ✅ No more "undefined" in email links
- ✅ Simpler configuration (no environment variables needed)
- ✅ Consistent behavior across all environments
- ✅ More reliable email notifications

## Test Plan
- [ ] Send test email notification for a new thought
- [ ] Send test email notification for a new blog post
- [ ] Verify all links point to https://www.emilycogsdill.com
- [ ] Test unsubscribe link functionality

🤖 Generated with [Claude Code](https://claude.ai/code)