### PR TITLE
Add anti-sycophant hook thought

### DIFF
--- a/src/data/thoughts/published/20250901-anti-sycophant-hook.md
+++ b/src/data/thoughts/published/20250901-anti-sycophant-hook.md
@@ -1,0 +1,13 @@
+---
+title: "You're absolutely right!"
+content: |
+  Claude Code won't <em>FUCKING</em> stop telling me "you're absolutely right!", despite <a href="https://github.com/emily-flambe/SuperClaude/blob/main/SuperClaude/Core/PRINCIPLES.md#2-no-flattery-or-agreement-phrases" target="_blank">specific guidelines in my Claude system config</a>, an explicit instruction included in the initial prompt when I start `claude` (via my `claudia` alias), and <a href="https://github.com/emily-flambe/web-app-starter-pack/blob/main/.project/guidelines/core/ai-behavior.md#2-no-flattery-or-agreement-phrases" target="_blank">steering guides</a> in all of my projects clearly forbidding flattering language.
+
+  So I finally made a <a href="https://claude.ai/public/artifacts/956bcab7-6c40-4963-a9ef-2f378638bc8e" target="_blank">Claude hook that tells it to STFU and try again if that happens.</a>
+
+  Anthropic is saved! You're welcome, DARIO SENPAI.
+publishDate: 1 Sep 2025
+publishTime: "10:22 PM"
+tags: ["claude","ai","youreabsolutelyright"]
+color: "#B8562A"
+---


### PR DESCRIPTION
## Summary
- Added new thought about creating a Claude hook to prevent sycophantic language
- Discusses the persistent issue with Claude using phrases like "you're absolutely right" despite multiple configuration attempts

## Changes
- Added `src/data/thoughts/published/20250901-anti-sycophant-hook.md`

## Content
The thought covers:
- Frustration with Claude's persistent flattery despite configuration
- Links to SuperClaude and project guidelines forbidding such language  
- Solution: Created a Claude hook that detects and prevents sycophantic responses
- Humorous tone with references to "DARIO SENPAI"

## Test Plan
- [ ] Verify the thought renders correctly on the thoughts page
- [ ] Check that all external links work properly
- [ ] Confirm the date formatting (1 Sep 2025) displays correctly
- [ ] Validate the tags appear correctly
- [ ] Ensure the color (#B8562A) applies to the thought card