### PR TITLE
Remove PROFILE link from navigation header

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -70,7 +70,4 @@ const user = Astro.locals.user;
   <a class={current === "museum" ? "selected" : ""} href='/museum'>museum</a>
   <a class={current === "bio" ? "selected" : ""} href='/bio'>bio</a>
   <a class={current === "chat" ? "selected" : ""} href='/chat'>chat</a>
-  {user && (
-    <a class={current === "profile" ? "selected" : ""} href='/profile'>profile</a>
-  )}
 </nav>


### PR DESCRIPTION
## Summary
- Removed the PROFILE link from the navigation header as requested
- The profile page remains accessible at `/profile` but won't appear in the main navigation

## Changes
- Deleted the conditional profile link rendering from `Nav.astro`
- Removed lines 73-75 which displayed "PROFILE" when a user was logged in

## Testing
- [ ] Verified navigation header no longer shows PROFILE link when logged in
- [ ] Confirmed `/profile` page is still accessible directly
- [ ] Tested on mobile and desktop viewports

🤖 Generated with [Claude Code](https://claude.ai/code)