### PR TITLE
Add PostHog analytics with View Transitions support (EMI-364)

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -21,6 +21,25 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 })(window,document,'script','dataLayer','GTM-NHPXWGM7');</script>
 <!-- End Google Tag Manager -->
 
+<!-- PostHog -->
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onSessionId setSuperProperties setPersonProperties".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_UVSiMPFA6WLD1s3Ea9GwI0rlVh5FrkCuheF4d8dTXRh', {
+    api_host: 'https://us.i.posthog.com',
+    person_profiles: 'identified_only',
+    capture_pageview: false,
+    capture_pageleave: true,
+  });
+</script>
+<script>
+  document.addEventListener('astro:page-load', () => {
+    if (window.posthog) {
+      window.posthog.capture('$pageview');
+    }
+  });
+</script>
+<!-- End PostHog -->
+
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width" />

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,14 @@
 /// <reference types="astro/client" />
 /// <reference types="@cloudflare/workers-types" />
 
+interface Window {
+  posthog?: {
+    capture: (event: string, properties?: Record<string, unknown>) => void;
+    identify: (distinctId: string, properties?: Record<string, unknown>) => void;
+    reset: () => void;
+  };
+}
+
 import type { Env } from './types/env';
 
 declare namespace App {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -11,6 +11,7 @@ export interface Props {
   current?: string;
 }
 const { title, description, permalink, current } = Astro.props;
+const user = Astro.locals.user;
 ---
 <html lang="en">
 <head>
@@ -32,6 +33,16 @@ const { title, description, permalink, current } = Astro.props;
 
     <Footer />
   </div>
+  {user && (
+    <script define:vars={{ userId: user.id, userEmail: user.email, username: user.username }}>
+      if (window.posthog) {
+        window.posthog.identify(userId, {
+          email: userEmail,
+          username: username,
+        });
+      }
+    </script>
+  )}
 </body>
 </html>
 


### PR DESCRIPTION
## Summary

- Adds PostHog JS snippet to `BaseHead.astro` alongside existing GTM, with `capture_pageview: false` to avoid double-counting
- Tracks pageviews via `astro:page-load` event so View Transitions navigations are captured correctly
- Calls `posthog.identify()` in `BaseLayout.astro` for authenticated users, only when `Astro.locals.user` is present
- Adds `Window.posthog` type declaration to `src/env.d.ts`

## Test plan

- [ ] Verify pageviews appear in PostHog dashboard on initial load
- [ ] Verify pageviews appear on View Transitions navigations (click between pages)
- [ ] Verify `identify()` fires for logged-in users and not for anonymous visitors
- [ ] Confirm no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)